### PR TITLE
Specify sync marker trait for TVF message in ProSA

### DIFF
--- a/prosa/proc.rs
+++ b/prosa/proc.rs
@@ -29,7 +29,7 @@ struct MyProcClass {}
 #[proc]
 impl<A> Proc<A> for MyProcClass
 where
-    A: Default + Adaptor + std::marker::Send,
+    A: Default + Adaptor + std::marker::Send + std::marker::Sync,
 {
     async fn internal_run(&mut self, _name: String) -> Result<(), Box<dyn std::error::Error>> {
         let mut adaptor = A::default();

--- a/prosa/src/core/main.rs
+++ b/prosa/src/core/main.rs
@@ -124,7 +124,7 @@ where
 
 impl<M> Main<M>
 where
-    M: Sized + Clone + Debug + Tvf + Default + 'static + std::marker::Send,
+    M: Sized + Clone + Debug + Tvf + Default + 'static + std::marker::Send + std::marker::Sync,
 {
     /// Method to instanciate a ProSA main task
     /// Must be called only one time
@@ -274,7 +274,7 @@ macro_rules! prosa_main_update_srv {
 
 impl<M> MainProc<M>
 where
-    M: Sized + Clone + Debug + Tvf + Default + 'static + std::marker::Send,
+    M: Sized + Clone + Debug + Tvf + Default + 'static + std::marker::Send + std::marker::Sync,
 {
     async fn remove_proc(&mut self, proc_id: u32) -> Option<HashMap<u32, ProcService<M>>> {
         if let Some(proc) = self.processors.remove(&proc_id) {
@@ -445,7 +445,7 @@ where
 
 impl<M> MainRunnable<M> for MainProc<M>
 where
-    M: Sized + Clone + Debug + Tvf + Default + 'static + std::marker::Send,
+    M: Sized + Clone + Debug + Tvf + Default + 'static + std::marker::Send + std::marker::Sync,
 {
     fn create<S: Settings>(settings: &S) -> (Main<M>, MainProc<M>) {
         let (internal_tx_queue, internal_rx_queue) = mpsc::channel(2048);

--- a/prosa/src/core/proc.rs
+++ b/prosa/src/core/proc.rs
@@ -18,6 +18,7 @@
 //! where
 //!     M: 'static
 //!     + std::marker::Send
+//!     + std::marker::Sync
 //!     + std::marker::Sized
 //!     + std::clone::Clone
 //!     + std::fmt::Debug
@@ -40,6 +41,7 @@
 //! where
 //!     M: 'static
 //!     + std::marker::Send
+//!     + std::marker::Sync
 //!     + std::marker::Sized
 //!     + std::clone::Clone
 //!     + std::fmt::Debug
@@ -68,26 +70,35 @@
 //! pub struct MyProc { /* Nothing in here */ }
 //!
 //! #[proc]
-//! impl<M> MyProc<M>
-//! where
-//!     M: 'static
-//!     + std::marker::Send
-//!     + std::marker::Sized
-//!     + std::clone::Clone
-//!     + std::fmt::Debug
-//!     + prosa_utils::msg::tvf::Tvf
-//!     + std::default::Default,
+//! impl MyProc
 //! {
 //!     fn internal_func() {
 //!         // You can declare function
 //!     }
 //! }
+//! // or explicitly
+//! //#[proc]
+//! //impl<M> MyProc<M>
+//! //where
+//! //    M: 'static
+//! //    + std::marker::Send
+//! //    + std::marker::Sync
+//! //    + std::marker::Sized
+//! //    + std::clone::Clone
+//! //    + std::fmt::Debug
+//! //    + prosa_utils::msg::tvf::Tvf
+//! //    + std::default::Default,
+//! //{
+//! //    fn internal_func() {
+//! //        // You can declare function
+//! //    }
+//! //}
 //!
 //! // You must implement the trait Proc to define your processing
 //! #[proc]
 //! impl<A> Proc<A> for MyProc
 //! where
-//!     A: Default + Adaptor + MyAdaptorTrait<M> + std::marker::Send,
+//!     A: Default + Adaptor + MyAdaptorTrait<M> + std::marker::Send + std::marker::Sync,
 //! {
 //!     async fn internal_run(&mut self, name: String) -> Result<(), Box<dyn std::error::Error>> {
 //!         // Initiate an adaptor for the stub processor
@@ -225,7 +236,7 @@ where
 
 impl<M> ProcParam<M>
 where
-    M: Sized + Clone + Debug + Tvf + Default + 'static + std::marker::Send,
+    M: Sized + Clone + Debug + Tvf + Default + 'static + std::marker::Send + std::marker::Sync,
 {
     /// Method to create a processor parameter
     pub fn new(id: u32, queue: mpsc::Sender<InternalMsg<M>>, main: Main<M>) -> ProcParam<M> {
@@ -337,6 +348,7 @@ pub trait ProcConfig<M>
 where
     M: 'static
         + std::marker::Send
+        + std::marker::Sync
         + std::marker::Sized
         + std::clone::Clone
         + std::fmt::Debug

--- a/prosa/src/core/service.rs
+++ b/prosa/src/core/service.rs
@@ -144,7 +144,7 @@ where
 
 impl<M> ProcService<M>
 where
-    M: Sized + Clone + Debug + Tvf + Default + 'static + std::marker::Send,
+    M: Sized + Clone + Debug + Tvf + Default + 'static + std::marker::Send + std::marker::Sync,
 {
     /// Method to create a processor service with its processor ID and a message queue
     pub fn new(

--- a/prosa/src/stub/adaptor.rs
+++ b/prosa/src/stub/adaptor.rs
@@ -24,6 +24,7 @@ use opentelemetry_sdk::metrics::MeterProvider;
 /// where
 ///     M: 'static
 ///         + std::marker::Send
+///         + std::marker::Sync
 ///         + std::marker::Sized
 ///         + std::clone::Clone
 ///         + std::fmt::Debug
@@ -44,6 +45,7 @@ pub trait StubAdaptor<M>
 where
     M: 'static
         + std::marker::Send
+        + std::marker::Sync
         + std::marker::Sized
         + std::clone::Clone
         + std::fmt::Debug
@@ -67,6 +69,7 @@ impl<M> StubAdaptor<M> for StubParotAdaptor
 where
     M: 'static
         + std::marker::Send
+        + std::marker::Sync
         + std::marker::Sized
         + std::clone::Clone
         + std::fmt::Debug

--- a/prosa/src/stub/proc.rs
+++ b/prosa/src/stub/proc.rs
@@ -73,7 +73,7 @@ pub struct StubProc {}
 #[proc]
 impl<A> Proc<A> for StubProc
 where
-    A: Default + Adaptor + StubAdaptor<M> + std::marker::Send,
+    A: Default + Adaptor + StubAdaptor<M> + std::marker::Send + std::marker::Sync,
 {
     async fn internal_run(&mut self, name: String) -> Result<(), Box<dyn std::error::Error>> {
         // Initiate an adaptor for the stub processor

--- a/prosa_macros/src/proc.rs
+++ b/prosa_macros/src/proc.rs
@@ -93,7 +93,7 @@ fn add_message_generic(generics: &mut syn::Generics) -> syn::parse::Result<()> {
     generics.make_where_clause();
     if let Some(ref mut where_clause) = generics.where_clause {
         let message_where: syn::WherePredicate = syn::parse2(
-            quote! { M: 'static + std::marker::Send + std::marker::Sized + std::clone::Clone + std::fmt::Debug + prosa_utils::msg::tvf::Tvf + std::default::Default },
+            quote! { M: 'static + std::marker::Send + std::marker::Sync + std::marker::Sized + std::clone::Clone + std::fmt::Debug + prosa_utils::msg::tvf::Tvf + std::default::Default },
         )?;
         where_clause.predicates.push(message_where);
     } else {
@@ -161,7 +161,7 @@ fn generate_struct_impl_bus_param(
     Ok(quote! {
         impl #item_generics prosa::core::proc::ProcBusParam for #item_ident #item_generics
         where
-            M: 'static + std::marker::Send + std::marker::Sized + std::clone::Clone + std::fmt::Debug + prosa_utils::msg::tvf::Tvf + std::default::Default,
+            M: 'static + std::marker::Send + std::marker::Sync + std::marker::Sized + std::clone::Clone + std::fmt::Debug + prosa_utils::msg::tvf::Tvf + std::default::Default,
         {
             #[doc=concat!(" Getter of the ", stringify!(#item_ident), " processor ID")]
             fn get_proc_id(&self) -> u32 {
@@ -191,7 +191,7 @@ fn generate_struct_impl_config(
         // The definition must be done for the protocol
         impl #item_generics prosa::core::proc::ProcConfig<M> for #item_ident #item_generics
         where
-            M: 'static + std::marker::Send + std::marker::Sized + std::clone::Clone + std::fmt::Debug + prosa_utils::msg::tvf::Tvf + std::default::Default,
+            M: 'static + std::marker::Send + std::marker::Sync + std::marker::Sized + std::clone::Clone + std::fmt::Debug + prosa_utils::msg::tvf::Tvf + std::default::Default,
         {
             type Settings = #settings;
 


### PR DESCRIPTION
In ProSA processor, TVF message are defined Send but not Sync.
In some processor, it must be Sync to be use in Tokio task.
Globally, a TVF must be Sync.