### PR TITLE
feat: allow deb, config, and container generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.profraw
 .idea
 .vscode
+.DS_Store

--- a/cargo-prosa/Cargo.toml
+++ b/cargo-prosa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-prosa"
-version = "0.1.1"
+version = "0.1.2"
 authors.workspace = true
 description = "ProSA utility to package and deliver a builded ProSA"
 homepage.workspace = true

--- a/cargo-prosa/README.md
+++ b/cargo-prosa/README.md
@@ -89,7 +89,7 @@ cargo prosa container --docker
 For your own needs, you can:
  - Select from which image the container need to be build `--image debian:stable-slim`
  - Along that you may have to specify the package manager use to install mandatory packages `--package_manager apt`
- - If you want to compile ProSA through a builder, you can specify it with `--builder rust:latest`. A multi stage container file will be create.
+ - If you want to compile ProSA through a builder, you can specify it with `--builder rust:latest`. A multi stage container file will be created.
 
 ### Deb package
 

--- a/cargo-prosa/README.md
+++ b/cargo-prosa/README.md
@@ -22,7 +22,7 @@ cargo prosa new my-prosa
 cargo prosa init
 ```
 
-cargo-prosa is meant to evolve in the future.
+_cargo-prosa_ is meant to evolve in the future.
 So maybe new things will be introduced.
 To update your model, you can update the generated file with `cargo prosa update`.
 
@@ -47,8 +47,9 @@ Your project uses a _build.rs_/_main.rs_ to create a binary that you can use.
 ## Configuration
 
 Keep in mind that you also need to have a settings file.
+A `target/config.yml` and `target/config.toml` will be generated when building.
 
-You can initiate a default one with:
+But you can initiate a default one with:
 ```bash
 cargo run -- -c default_config.yaml --dry_run
 ```
@@ -69,3 +70,32 @@ cargo run -- -n "MyBuiltProSA" -c default_config.yaml
 # or with binary
 target/debug/my-prosa -n "MyBuiltProSA" -c default_config.yaml
 ```
+
+## Deploy
+
+This builder offer you several possibilities to deploy your ProSA.
+The goal is to use the easiest method of a plateform to run your application.
+
+### Container
+
+Containerization will allow you to build and load ProSA in an image:
+```bash
+# Generate a Containerfile
+cargo prosa container
+# Generate a Dockerfile
+cargo prosa container --docker
+```
+
+For your own needs, you can:
+ - Select from which image the container need to be build `--image debian:stable-slim`
+ - Along that you may have to specify the package manager use to install mandatory packages `--package_manager apt`
+ - If you want to compile ProSA through a builder, you can specify it with `--builder rust:latest`. A multi stage container file will be create.
+
+### Deb package
+
+Deb package can be created with the [cargo-deb](https://crates.io/crates/cargo-deb) crate.
+
+To enable this feature, _create_, _init_ or _update_ your ProSA with the option `--deb`.
+It'll add every needed properties to generate a deb package.
+
+The deb package will include the released binary, a default configuration file, and a systemd service file.

--- a/cargo-prosa/assets/build.rs.j2
+++ b/cargo-prosa/assets/build.rs.j2
@@ -1,13 +1,15 @@
 use std::collections::HashMap;
 use std::io::Write;
-use std::{{ '{' }}env, io{{ '}' }};
+use std::{{ '{' }}env, io, path{{ '}' }};
 use std::ffi::OsString;
-use std::fs;
-use std::path::Path;
+use std::{{ '{' }}fs, path::Path{{ '}' }};
 
 use cargo_prosa::builder::Desc;
 use cargo_prosa::cargo::{{ '{' }}CargoMetadata, Metadata{{ '}' }};
 use cargo_prosa::CONFIGURATION_FILENAME;
+{%- if deb_pkg %}
+use cargo_prosa::package::deb::DebPkg;
+{% endif %}
 
 fn write_settings_rs(out_dir: &OsString, desc: &Desc, metadata: &HashMap<String, Metadata>) -> io::Result<()> {{ '{' }}
     let mut f = fs::File::create(Path::new(&out_dir).join("settings.rs"))?;
@@ -114,7 +116,7 @@ fn write_run_rs(out_dir: &OsString, desc: &Desc, metadata: &HashMap<String, Meta
             proc_id += 1;
             writeln!(f, "debug!(\"Start processor {{ '{}' }}\");", processor.get_name())?;
             let proc_metadata = metadata.get(&processor.proc_name).unwrap_or_else(|| panic!("Can't get the processor {{ '{}' }} metadata ({{ '{:?}' }})", processor.proc, processor.name));
-            if let Some(_) = &proc_metadata.settings {{ '{' }}
+            if proc_metadata.settings.is_some() {{ '{' }}
                 writeln!(f, "let proc = {{ '{}' }}::<{{ '{}' }}>::create({{ '{}' }}, bus.clone(), settings.{{ '{}' }}.clone());", processor.proc, desc.prosa.tvf, proc_id, processor.get_name().replace('-', "_"))?;
             {{ '}' }} else {{ '{' }}
                 writeln!(f, "let proc = {{ '{}' }}::<{{ '{}' }}>::create_raw({{ '{}' }}, bus.clone());", processor.proc, desc.prosa.tvf, proc_id)?;
@@ -176,8 +178,73 @@ fn write_run_rs(out_dir: &OsString, desc: &Desc, metadata: &HashMap<String, Meta
     writeln!(f, "{{ '}}' }}")
 {{ '}' }}
 
+fn write_target_config(out_dir: &OsString, target_dir: &Path) -> io::Result<()> {{ '{' }}
+    // Create temporary project to generate config file
+    let prosa_config_path = Path::new(&out_dir).join("prosa_config");
+    fs::create_dir_all(prosa_config_path.join("src"))?;
+    fs::copy(Path::new(&out_dir).join("settings.rs"), prosa_config_path.join("src").join("settings.rs"))?;
+
+    // Correct relative path in the Cargo.toml by the `out_dir` one
+    let cargo_content = fs::read_to_string("Cargo.toml")?.replace("\"../", format!("\"{}/../", env::current_dir()?.display()).as_str());
+    let mut cargo_dst = fs::File::create(&prosa_config_path.join("Cargo.toml"))?;
+    cargo_dst.write(cargo_content.as_bytes())?;
+
+    let mut f = fs::File::create(prosa_config_path.join("src").join("main.rs"))?;
+    writeln!(f, "use prosa::core::settings::Settings;\n")?;
+    writeln!(f, "use serde::{{ '{{' }}Deserialize, Serialize{{ '}}' }};\n")?;
+    writeln!(f, "include!(\"settings.rs\");\n")?;
+    writeln!(f, "fn main() -> std::io::Result<()> {{ '{{' }}")?;
+    writeln!(f, "    let args: Vec<String> = std::env::args().collect();")?;
+    writeln!(f, "    RunSettings::default().write_config(args.last().expect(\"Missing config path\"))")?;
+    writeln!(f, "{{ '}}' }}")?;
+
+    let config_build_yml = std::process::Command::new("cargo")
+        .args(["run", "--", target_dir.join("config.yml").to_str().unwrap()])
+        .current_dir(&prosa_config_path)
+        .output()
+        .expect("Failed to generate config.yml");
+    if !config_build_yml.status.success() {{ '{' }}
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            std::str::from_utf8(config_build_yml.stderr.as_slice()).unwrap_or(
+                format!(
+                    "Can't build config.yml config file {:?}",
+                    config_build_yml.status.code()
+                )
+                .as_str(),
+            ),
+        ));
+    {{ '}' }}
+
+    let config_build_toml = std::process::Command::new("cargo")
+        .args([
+            "run",
+            "--",
+            target_dir.join("config.toml").to_str().unwrap(),
+        ])
+        .current_dir(&prosa_config_path)
+        .output()
+        .expect("Failed to generate config.toml");
+    if !config_build_toml.status.success() {{ '{' }}
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            std::str::from_utf8(config_build_toml.stderr.as_slice()).unwrap_or(
+                format!(
+                    "Can't build config.toml config file {{ '{' }}:?{{ '}' }}",
+                    config_build_toml.status.code()
+                )
+                .as_str(),
+            ),
+        ));
+    {{ '}' }}
+
+    Ok(())
+{{ '}' }}
+
 fn main() {{ '{' }}
+    // Generate Rust code for ProSA
     let out_dir = env::var_os("OUT_DIR").unwrap();
+    let target_path = path::absolute("target").unwrap();
     let cargo_metadata = CargoMetadata::load_metadata().unwrap();
     let prosa_proc_metadata = cargo_metadata.prosa_proc_metadata();
     let prosa_desc = toml::from_str::<Desc>(fs::read_to_string(CONFIGURATION_FILENAME).unwrap().as_str()).unwrap();
@@ -186,6 +253,17 @@ fn main() {{ '{' }}
     write_config_rs(&out_dir, &prosa_desc, &cargo_metadata).unwrap();
     write_run_rs(&out_dir, &prosa_desc, &prosa_proc_metadata).unwrap();
 
+    write_target_config(&out_dir, &target_path).unwrap();
+
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=ProSA.toml");
+{%- if deb_pkg %}
+    println!("cargo:rerun-if-changed=Cargo.toml");
+
+    // Generate files for ProSA packages
+{% endif -%}
+{%- if deb_pkg %}
+    let deb_pkg = DebPkg::new(target_path.to_path_buf()).unwrap();
+    deb_pkg.write_package_data().unwrap();
+{% endif -%}
 {{ '}' }}

--- a/cargo-prosa/assets/container.j2
+++ b/cargo-prosa/assets/container.j2
@@ -1,0 +1,50 @@
+{% if builder_image is defined -%}
+FROM {{ builder_image }} AS builder
+WORKDIR /opt
+COPY . .
+
+RUN mkdir -p ~/.ssh \
+ && touch ~/.ssh/config \
+ && echo "Host *\n    StrictHostKeyChecking=accept-new" >> ~/.ssh/config \
+ && chmod 644 ~/.ssh/config
+
+{% if package_manager == "apt" -%}
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get -y update && apt-get -y install \
+      libssl-dev
+{% endif -%}
+
+{% if docker -%}
+RUN --mount=type=ssh export CARGO_NET_GIT_FETCH_WITH_CLI=true \
+ && cargo build -r
+{% else %}
+RUN cargo build -r
+{% endif %}
+{% endif -%}
+FROM {{ image }}
+
+LABEL org.opencontainers.image.title="{{ name }}"
+LABEL org.opencontainers.image.version="{{ version }}"
+{% if license is defined %}LABEL org.opencontainers.image.licenses="{{ license }}"{% endif %}
+{% if authors is defined %}LABEL org.opencontainers.image.authors="{{ authors | join(sep=", ") }}"{% endif %}
+{% if description is defined %}LABEL org.opencontainers.image.description="{{ description }}"{% endif %}
+{% if documentation is defined %}LABEL org.opencontainers.image.documentation="{{ documentation }}"{% endif %}
+
+{% if builder_image is defined -%}
+COPY --from=builder --chmod=755 /opt/target/release/{{ name }} /usr/local/bin/{{ name }}
+{% else %}
+COPY --chmod=755 target/release/{{ name }} /usr/local/bin/{{ name }}
+{% endif -%}
+
+{% if package_manager == "apt" %}
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get -y update && apt-get -y install \
+      libssl3 \
+ && apt-get -y clean && apt-get -y autoclean \
+ && rm -rf /tmp/* \
+ && /usr/local/bin/{{ name }} -c /etc/{{ name }}.yml --dry_run
+{% else %}
+RUN /usr/local/bin/{{ name }} -c /etc/{{ name }}.yml --dry_run
+{% endif %}
+
+ENTRYPOINT ["/usr/local/bin/{{ name }}", "-c", "/etc/{{ name }}.yml"]

--- a/cargo-prosa/assets/systemd.j2
+++ b/cargo-prosa/assets/systemd.j2
@@ -1,0 +1,13 @@
+[Unit]
+{% if description is defined %}Description={{ description }}{% endif %}
+{% if documentation is defined %}Documentation={{ documentation }}{% endif %}
+After=network-online.target
+ConditionFileNotEmpty={{ config }}
+
+[Service]
+ExecStart={{ bin }} -c {{ config }}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+Alias={{ name }}.service

--- a/cargo-prosa/src/lib.rs
+++ b/cargo-prosa/src/lib.rs
@@ -11,6 +11,8 @@
 /// Configuration file name for ProSA. Define all processor list
 pub const CONFIGURATION_FILENAME: &str = "ProSA.toml";
 
+pub mod package;
+
 pub mod builder;
 
 pub mod cargo;

--- a/cargo-prosa/src/package.rs
+++ b/cargo-prosa/src/package.rs
@@ -1,0 +1,7 @@
+//! Module to package a ProSA
+
+/// Module to package ProSA into a container image
+pub mod container;
+
+/// Module to package ProSA in debian package (`.deb`)
+pub mod deb;

--- a/cargo-prosa/src/package/container.rs
+++ b/cargo-prosa/src/package/container.rs
@@ -1,0 +1,127 @@
+use std::{
+    fmt, fs, io,
+    path::{Path, PathBuf},
+};
+
+use clap::ArgMatches;
+use tera::Tera;
+
+use crate::cargo::CargoMetadata;
+
+/// Struct to handle Container file creation
+pub struct ContainerFile {
+    is_docker: bool,
+    ctx: tera::Context,
+    path: Option<String>,
+}
+
+impl ContainerFile {
+    /// Create a container file builder from `cargo-prosa` command arguments
+    pub fn new(args: &ArgMatches) -> io::Result<ContainerFile> {
+        let package_metadata = CargoMetadata::load_package_metadata()?;
+        let is_docker = args.get_flag("docker");
+        let mut ctx = tera::Context::new();
+        package_metadata.j2_context(&mut ctx);
+        ctx.insert("docker", &is_docker);
+        ctx.insert(
+            "image",
+            args.get_one::<String>("image")
+                .expect("required container base image"),
+        );
+        ctx.insert(
+            "package_manager",
+            args.get_one::<String>("package_manager")
+                .expect("required package manager"),
+        );
+        let builder_img = args.get_one::<String>("builder");
+        if let Some(img) = builder_img {
+            ctx.insert("builder_image", img);
+        }
+
+        Ok(ContainerFile {
+            is_docker,
+            ctx,
+            path: args.get_one::<String>("PATH").cloned(),
+        })
+    }
+
+    /// Method to get the path of the Dockerfile/Containerfile
+    pub fn get_path(&self) -> PathBuf {
+        if let Some(p) = &self.path {
+            let path = Path::new(p);
+            if path.is_dir() {
+                if self.is_docker {
+                    path.join("Dockerfile")
+                } else {
+                    path.join("Containerfile")
+                }
+            } else {
+                path.to_path_buf()
+            }
+        } else if self.is_docker {
+            Path::new("Dockerfile").to_path_buf()
+        } else {
+            Path::new("Containerfile").to_path_buf()
+        }
+    }
+
+    /// Method to create a container file
+    pub fn create_container_file(&self) -> tera::Result<()> {
+        let template_name = if self.is_docker {
+            "Dockerfile"
+        } else {
+            "Containerfile"
+        };
+
+        let mut tera_build = Tera::default();
+        tera_build.add_raw_template(
+            template_name,
+            include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/container.j2")),
+        )?;
+
+        let build_file = fs::File::create(self.get_path()).map_err(tera::Error::io_error)?;
+        tera_build.render_to(template_name, &self.ctx, build_file)
+    }
+}
+
+impl fmt::Display for ContainerFile {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let img_name = format!(
+            "{}:{}",
+            self.ctx.get("name").unwrap().as_str().unwrap(),
+            self.ctx.get("version").unwrap().as_str().unwrap()
+        );
+        writeln!(f, "To build your container, use the command:")?;
+        if self.is_docker {
+            write!(f, "  `docker build")?;
+            if self.path.is_some() {
+                write!(f, " -f {}", self.get_path().display())?;
+            }
+            writeln!(f, " -t {} .`", img_name)?;
+
+            if self.ctx.contains_key("builder_image") {
+                writeln!(
+                    f,
+                    "If you have an external git dependency, specify your ssh agent with:"
+                )?;
+
+                write!(f, "  `docker build")?;
+                if self.path.is_some() {
+                    write!(f, " -f {}", self.get_path().display())?;
+                }
+                writeln!(f, " --ssh default=$SSH_AUTH_SOCK -t {} .`", img_name)
+            } else {
+                Ok(())
+            }
+        } else if self.path.is_some() {
+            writeln!(
+                f,
+                "  `podman build -f {} -t {} .`",
+                self.get_path().display(),
+                img_name
+            )
+        } else {
+            writeln!(f, "  `podman build -t {} .`", img_name)
+        }
+    }
+}

--- a/cargo-prosa/src/package/deb.rs
+++ b/cargo-prosa/src/package/deb.rs
@@ -1,0 +1,148 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use tera::Tera;
+
+use crate::cargo::CargoMetadata;
+
+/// Struct to handle Container file creation
+pub struct DebPkg {
+    path: PathBuf,
+    ctx: tera::Context,
+}
+
+impl DebPkg {
+    const DEB_DATA_TARGET: &'static str = "prosa-deb";
+
+    /// Create a debian package builder from build.rs script
+    pub fn new(path: PathBuf) -> io::Result<DebPkg> {
+        let package_metadata = CargoMetadata::load_package_metadata()?;
+        let mut ctx = tera::Context::new();
+        package_metadata.j2_context(&mut ctx);
+
+        // Add package build context
+        ctx.insert(
+            "config",
+            &format!("/etc/ProSA/{}.yml", package_metadata.name),
+        );
+        ctx.insert("bin", &format!("/usr/bin/{}", package_metadata.name));
+
+        Ok(DebPkg { path, ctx })
+    }
+
+    fn get_binary_assets(name: &str) -> toml_edit::Array {
+        let mut binary_assets = toml_edit::Array::new();
+        binary_assets.push(format!("target/release/{}", name));
+        binary_assets.push("usr/bin/");
+        binary_assets.push("755");
+        binary_assets
+    }
+
+    fn get_config_assets(name: &str) -> toml_edit::Array {
+        let mut config_assets = toml_edit::Array::new();
+        config_assets.push(format!("target/{}/{}.yml", Self::DEB_DATA_TARGET, name));
+        config_assets.push("etc/ProSA/");
+        config_assets.push("644");
+        config_assets
+    }
+
+    fn get_readme_assets(name: &str) -> toml_edit::Array {
+        let mut readme_assets = toml_edit::Array::new();
+        readme_assets.push("README.md");
+        readme_assets.push(format!("usr/share/doc/{}/README", name));
+        readme_assets.push("644");
+        readme_assets
+    }
+
+    /// Function to add debian package metadata to `Cargo.toml`
+    pub fn add_deb_pkg_metadata(deb_table: &mut toml_edit::Table, name: &str) {
+        if !deb_table.contains_key("depends") {
+            deb_table.insert(
+                "depends",
+                toml_edit::Item::Value(toml_edit::Value::String(toml_edit::Formatted::new(
+                    "$auto, libssl3".to_string(),
+                ))),
+            );
+        }
+
+        if !deb_table.contains_key("maintainer-scripts") {
+            deb_table.insert(
+                "maintainer-scripts",
+                toml_edit::Item::Value(format!("target/{}/", Self::DEB_DATA_TARGET).into()),
+            );
+        }
+
+        if !deb_table.contains_key("assets") {
+            // Add every assets properties to deb table
+            let mut assets = toml_edit::Array::new();
+
+            assets.push(Self::get_binary_assets(name));
+            assets.push(Self::get_config_assets(name));
+
+            if Path::new("README.md").is_file() {
+                assets.push(Self::get_readme_assets(name));
+            }
+
+            deb_table.insert("assets", toml_edit::Item::Value(assets.into()));
+        }
+
+        if let Some(toml_edit::Item::Value(toml_edit::Value::InlineTable(systemd_units))) =
+            deb_table.get_mut("systemd-units")
+        {
+            if !systemd_units.contains_key("enable") {
+                systemd_units.insert(
+                    "enable",
+                    toml_edit::Value::Boolean(toml_edit::Formatted::new(true)),
+                );
+            }
+        } else {
+            let mut inline_table = toml_edit::InlineTable::new();
+
+            inline_table.insert(
+                "enable",
+                toml_edit::Value::Boolean(toml_edit::Formatted::new(true)),
+            );
+
+            deb_table.insert(
+                "systemd-units",
+                toml_edit::Item::Value(toml_edit::Value::InlineTable(inline_table)),
+            );
+        }
+    }
+
+    /// Method to write package data (useful for the deb package) into a folder
+    pub fn write_package_data(&self) -> io::Result<()> {
+        let name = self
+            .ctx
+            .get("name")
+            .and_then(|n| n.as_str())
+            .ok_or(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Missing package name",
+            ))?;
+        let pkg_data_path = self.path.join(Self::DEB_DATA_TARGET);
+        fs::create_dir_all(&pkg_data_path)?;
+
+        // Copy configuration file
+        fs::copy(
+            self.path.join("config.yml"),
+            pkg_data_path.join(format!("{}.yml", name)),
+        )?;
+
+        // Write systemd file
+        let mut tera_build = Tera::default();
+        tera_build
+            .add_raw_template(
+                "prosa.service",
+                include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/systemd.j2")),
+            )
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        let main_file = fs::File::create(pkg_data_path.join("service"))?;
+        tera_build
+            .render_to("prosa.service", &self.ctx, main_file)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+}

--- a/cargo-prosa/tests/cargo-prosa.rs
+++ b/cargo-prosa/tests/cargo-prosa.rs
@@ -72,6 +72,11 @@ fn project() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("list");
     cmd.assert().success().stdout(predicate::str::is_match(
         r"Package prosa\[[0-9].[0-9].[0-9]\] \(ProSA core\)
+  - inj
+    Processor inj::proc::InjProc
+    Settings inj::proc::InjSettings
+    Adaptor:
+     - inj::adaptor::InjDummyAdaptor
   - main
     - core::main::MainProc
   - stub

--- a/cargo-prosa/tests/cargo-prosa.rs
+++ b/cargo-prosa/tests/cargo-prosa.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::{env, fs};
 
 use assert_cmd::{cargo, Command};
@@ -10,6 +11,27 @@ fn cargo_prosa_command() -> Result<Command, cargo::CargoError> {
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME"))?;
     cmd.arg("prosa");
     Ok(cmd)
+}
+
+/// To test the dummy ProSA, we need to change the dependencies to take the local one
+fn replace_prosa_dependencies(prosa_path: &PathBuf) {
+    let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    test_path.pop();
+    for (prosa_dep, prosa_dep_path, build_opt) in [
+        ("prosa-utils", "prosa_utils", None),
+        ("prosa", "prosa", None),
+        ("cargo-prosa", "cargo-prosa", Some(["--build"])),
+    ] {
+        let test_prosa_dep = test_path.join(prosa_dep_path);
+        let mut cmd = Command::new("cargo");
+        cmd.arg("add");
+        cmd.current_dir(prosa_path);
+        if let Some(opt) = build_opt {
+            cmd.args(opt);
+        }
+        cmd.args(["--path", test_prosa_dep.to_str().unwrap(), prosa_dep]);
+        cmd.assert().success();
+    }
 }
 
 #[test]
@@ -35,13 +57,14 @@ fn project() -> Result<(), Box<dyn std::error::Error>> {
     // Generate a dummy project
     let mut cmd = cargo_prosa_command()?;
     cmd.current_dir(&temp_dir);
-    cmd.args(["new", PROSA_NAME]);
+    cmd.args(["new", "--deb", PROSA_NAME]);
     cmd.assert()
         .success()
         .stderr(predicate::str::contains(format!(
             "binary (application) `{}` package",
             PROSA_NAME
         )));
+    replace_prosa_dependencies(&prosa_path);
 
     // List all component available for ProSA
     let mut cmd = cargo_prosa_command()?;
@@ -119,6 +142,13 @@ Package prosa-utils\[[0-9].[0-9].[0-9]\] \(ProSA utils\)
     cmd.current_dir(&prosa_path);
     cmd.assert().success();
 
+    // Test if build have generated everything
+    assert!(prosa_path
+        .join("target")
+        .join("prosa-deb")
+        .join("service")
+        .exists());
+
     // Try to update the ProSA
     let build_path = prosa_path.join("build.rs");
     let _ = fs::remove_file(&build_path);
@@ -128,6 +158,38 @@ Package prosa-utils\[[0-9].[0-9].[0-9]\] \(ProSA utils\)
     cmd.arg("update");
     cmd.assert().success();
     assert!(build_path.exists());
+
+    // Try to generate container files
+    let (containerfile_path, dockerfile_path) = (
+        prosa_path.join("Containerfile"),
+        prosa_path.join("Dockerfile"),
+    );
+    let _ = fs::remove_file(&containerfile_path);
+    let _ = fs::remove_file(&dockerfile_path);
+    assert!(!containerfile_path.exists() && !dockerfile_path.exists());
+    let mut cmd = cargo_prosa_command()?;
+    cmd.current_dir(&prosa_path);
+    cmd.args(["container", containerfile_path.to_str().unwrap()]);
+    cmd.assert().success().stdout(predicate::str::is_match(
+        r"To build your container, use the command:
+  `podman build -f .*/dummy-test-prosa/Containerfile -t dummy-test-prosa:0\.1\.0 \.`",
+    )?);
+    assert!(containerfile_path.exists());
+    let mut cmd = cargo_prosa_command()?;
+    cmd.current_dir(&prosa_path);
+    cmd.args([
+        "container",
+        "--docker",
+        "-b rust-latest",
+        dockerfile_path.to_str().unwrap(),
+    ]);
+    cmd.assert().success().stdout(predicate::str::is_match(
+        r"To build your container, use the command:
+  `docker build -f .*/dummy-test-prosa/Dockerfile -t dummy-test-prosa:0\.1\.0 \.`
+If you have an external git dependency, specify your ssh agent with:
+  `docker build -f .*/dummy-test-prosa/Dockerfile --ssh default=\$SSH_AUTH_SOCK -t dummy-test-prosa:0\.1\.0 \.`",
+    )?);
+    assert!(dockerfile_path.exists());
 
     // Remove a stub processor (dry_run)
     let mut cmd = cargo_prosa_command()?;
@@ -152,6 +214,7 @@ Package prosa-utils\[[0-9].[0-9].[0-9]\] \(ProSA utils\)
     cmd.arg("init");
     cmd.assert().success();
     assert!(build_path.exists());
+    replace_prosa_dependencies(&prosa_path);
 
     // Get Bash command completion
     let mut cmd = cargo_prosa_command()?;


### PR DESCRIPTION
- Generate configuration file directly into `target/config.yml` and `target/config.toml`.
- Add `container` command to generate _Containerfile_ or _Dockerfile_ to make ProSA container images.
- Allow deb package with [cargo-deb](https://crates.io/crates/cargo-deb).