### PR TITLE
Code style improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To build one, please refer to [cargo-prosa](./cargo-prosa/README.md).
 
 - [Jérémy HERGAULT](https://github.com/reneca)
 - [Anthony THOMAS](https://github.com/Timmy80)
-- [Olivier SCHYNS](https://github.com/SchynsO)
+- [Olivier SCHYNS](https://github.com/oschijns)
 - [René-Louis EYMARD](https://github.com/rleymard)
 
 ### Posterity

--- a/prosa/proc.rs
+++ b/prosa/proc.rs
@@ -44,7 +44,7 @@ where
             tokio::select! {
                 Some(msg) = self.internal_rx_queue.recv() => {
                     match msg {
-                        InternalMsg::REQUEST(msg) => {
+                        InternalMsg::Request(msg) => {
                             info!("Proc {} receive a request: {:?}", self.get_proc_id(), msg);
 
 
@@ -52,21 +52,21 @@ where
                             pending_msgs.push(msg, Duration::from_millis(200));
                             //msg.return_to_sender(tvf).await.unwrap();
                         },
-                        InternalMsg::RESPONSE(msg) => {
+                        InternalMsg::Response(msg) => {
                             let _enter = msg.enter_span();
                             info!("Proc {} receive a response: {:?}", self.get_proc_id(), msg);
                         },
-                        InternalMsg::ERROR(err) => {
+                        InternalMsg::Error(err) => {
                             let _enter = err.enter_span();
                             info!("Proc {} receive an error: {:?}", self.get_proc_id(), err);
                         },
-                        InternalMsg::COMMAND(_) => todo!(),
-                        InternalMsg::CONFIG => todo!(),
-                        InternalMsg::SERVICE(table) => {
+                        InternalMsg::Command(_) => todo!(),
+                        InternalMsg::Config => todo!(),
+                        InternalMsg::Service(table) => {
                             debug!("New service table received:\n{}\n", table);
                             self.service = table;
                         },
-                        InternalMsg::SHUTDOWN => {
+                        InternalMsg::Shutdown => {
                             adaptor.terminate();
                             warn!("The processor will shut down");
                         },
@@ -82,14 +82,14 @@ where
                     let stub_service_name = String::from("STUB_TEST");
                     if let Some(service) = self.service.get_proc_service(&stub_service_name, msg_id) {
                         debug!("The service is find: {:?}", service);
-                        service.proc_queue.send(InternalMsg::REQUEST(RequestMsg::new(msg_id, stub_service_name, tvf.clone(), self.proc.get_service_queue()))).await.unwrap();
+                        service.proc_queue.send(InternalMsg::Request(RequestMsg::new(msg_id, stub_service_name, tvf.clone(), self.proc.get_service_queue()))).await.unwrap();
                         msg_id += 1;
                     }
 
                     let proc_service_name = String::from("PROC_TEST");
                     if let Some(service) = self.service.get_proc_service(&proc_service_name, msg_id) {
                         debug!("The service is find: {:?}", service);
-                        service.proc_queue.send(InternalMsg::REQUEST(RequestMsg::new(msg_id, proc_service_name, tvf, self.proc.get_service_queue()))).await.unwrap();
+                        service.proc_queue.send(InternalMsg::Request(RequestMsg::new(msg_id, proc_service_name, tvf, self.proc.get_service_queue()))).await.unwrap();
                         msg_id += 1;
                     }
                 },

--- a/prosa/proc.rs
+++ b/prosa/proc.rs
@@ -115,6 +115,7 @@ struct MySettings {
     // Can add parameters here
 }
 
+#[allow(clippy::needless_return)]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // load the configuration

--- a/prosa/src/core/adaptor.rs
+++ b/prosa/src/core/adaptor.rs
@@ -36,7 +36,7 @@ pub use prosa_macros::Adaptor;
 /// ```
 /// use prosa::core::adaptor::Adaptor;
 ///
-/// #[derive(Default, Adaptor)]
+/// #[derive(Adaptor)]
 /// struct MyAdaptor {}
 /// ```
 pub trait Adaptor {

--- a/prosa/src/core/adaptor.rs
+++ b/prosa/src/core/adaptor.rs
@@ -39,7 +39,7 @@ pub use prosa_macros::Adaptor;
 /// #[derive(Default, Adaptor)]
 /// struct MyAdaptor {}
 /// ```
-pub trait Adaptor<T: Default = Self> {
+pub trait Adaptor {
     /// Method call when the ProSA need to shut down.
     /// This method is call only once so the processing will be thread safe.
     fn terminate(&mut self);

--- a/prosa/src/core/main.rs
+++ b/prosa/src/core/main.rs
@@ -144,7 +144,7 @@ where
             .await
             .map_err(|e| {
                 BusError::InternalMainQueueError(
-                    "NEWPROCQUEUE".into(),
+                    "NewProcQueue".into(),
                     proc.get_proc_id(),
                     e.to_string(),
                 )
@@ -156,7 +156,9 @@ where
         self.internal_tx_queue
             .send(InternalMainMsg::DeleteProc(proc_id))
             .await
-            .map_err(|e| BusError::InternalMainQueueError("DELPROC".into(), proc_id, e.to_string()))
+            .map_err(|e| {
+                BusError::InternalMainQueueError("DeleteProc".into(), proc_id, e.to_string())
+            })
     }
 
     /// Method to declare a new processor on the main bus
@@ -165,7 +167,7 @@ where
             .send(InternalMainMsg::DeleteProcQueue(proc_id, queue_id))
             .await
             .map_err(|e| {
-                BusError::InternalMainQueueError("DELPROCQUEUE".into(), proc_id, e.to_string())
+                BusError::InternalMainQueueError("DeleteProcQueue".into(), proc_id, e.to_string())
             })
     }
 
@@ -175,7 +177,7 @@ where
             .send(InternalMainMsg::NewProcService(names, proc_id))
             .await
             .map_err(|e| {
-                BusError::InternalMainQueueError("NEWPROCSRV".into(), proc_id, e.to_string())
+                BusError::InternalMainQueueError("NewProcService".into(), proc_id, e.to_string())
             })
     }
 
@@ -189,7 +191,9 @@ where
         self.internal_tx_queue
             .send(InternalMainMsg::NewService(names, proc_id, queue_id))
             .await
-            .map_err(|e| BusError::InternalMainQueueError("NEWSRV".into(), proc_id, e.to_string()))
+            .map_err(|e| {
+                BusError::InternalMainQueueError("NewService".into(), proc_id, e.to_string())
+            })
     }
 
     /// Method to remove a service for a whole processor from the main bus
@@ -198,7 +202,7 @@ where
             .send(InternalMainMsg::DeleteProcService(names, proc_id))
             .await
             .map_err(|e| {
-                BusError::InternalMainQueueError("DELPROCSRV".into(), proc_id, e.to_string())
+                BusError::InternalMainQueueError("DeleteProcService".into(), proc_id, e.to_string())
             })
     }
 
@@ -212,7 +216,9 @@ where
         self.internal_tx_queue
             .send(InternalMainMsg::DeleteService(names, proc_id, queue_id))
             .await
-            .map_err(|e| BusError::InternalMainQueueError("DELSRV".into(), proc_id, e.to_string()))
+            .map_err(|e| {
+                BusError::InternalMainQueueError("DeleteService".into(), proc_id, e.to_string())
+            })
     }
 
     /// Method to stop all processors
@@ -220,7 +226,7 @@ where
         self.internal_tx_queue
             .send(InternalMainMsg::Shutdown(reason))
             .await
-            .map_err(|e| BusError::InternalMainQueueError("SHUTDOWN".into(), 0, e.to_string()))
+            .map_err(|e| BusError::InternalMainQueueError("Shutdown".into(), 0, e.to_string()))
     }
 
     /// Provide the ProSA name based on ProSA settings

--- a/prosa/src/core/main.rs
+++ b/prosa/src/core/main.rs
@@ -78,7 +78,7 @@ where
 ///     proc_queue[(Processor queue)]
 ///     proc_task[Processor task]
 ///     proc_io[Processor IOs]
-///     
+///
 ///     table <--> main_task
 ///     table --> proc_task
 ///     proc_task --> main_queue
@@ -140,7 +140,7 @@ where
     /// Method to declare a new processor on the main bus
     pub async fn add_proc_queue(&self, proc: ProcService<M>) -> Result<(), BusError> {
         self.internal_tx_queue
-            .send(InternalMainMsg::NEWPROCQUEUE(proc.clone()))
+            .send(InternalMainMsg::NewProcQueue(proc.clone()))
             .await
             .map_err(|e| {
                 BusError::InternalMainQueueError(
@@ -154,7 +154,7 @@ where
     /// Method to remove an entire processor from the main bus
     pub async fn rm_proc(&self, proc_id: u32) -> Result<(), BusError> {
         self.internal_tx_queue
-            .send(InternalMainMsg::DELPROC(proc_id))
+            .send(InternalMainMsg::DeleteProc(proc_id))
             .await
             .map_err(|e| BusError::InternalMainQueueError("DELPROC".into(), proc_id, e.to_string()))
     }
@@ -162,7 +162,7 @@ where
     /// Method to declare a new processor on the main bus
     pub async fn rm_proc_queue(&self, proc_id: u32, queue_id: u32) -> Result<(), BusError> {
         self.internal_tx_queue
-            .send(InternalMainMsg::DELPROCQUEUE(proc_id, queue_id))
+            .send(InternalMainMsg::DeleteProcQueue(proc_id, queue_id))
             .await
             .map_err(|e| {
                 BusError::InternalMainQueueError("DELPROCQUEUE".into(), proc_id, e.to_string())
@@ -172,7 +172,7 @@ where
     /// Method to declare a new service for a whole processor on the main bus
     pub async fn add_service_proc(&self, names: Vec<String>, proc_id: u32) -> Result<(), BusError> {
         self.internal_tx_queue
-            .send(InternalMainMsg::NEWPROCSRV(names, proc_id))
+            .send(InternalMainMsg::NewProcService(names, proc_id))
             .await
             .map_err(|e| {
                 BusError::InternalMainQueueError("NEWPROCSRV".into(), proc_id, e.to_string())
@@ -187,7 +187,7 @@ where
         queue_id: u32,
     ) -> Result<(), BusError> {
         self.internal_tx_queue
-            .send(InternalMainMsg::NEWSRV(names, proc_id, queue_id))
+            .send(InternalMainMsg::NewService(names, proc_id, queue_id))
             .await
             .map_err(|e| BusError::InternalMainQueueError("NEWSRV".into(), proc_id, e.to_string()))
     }
@@ -195,7 +195,7 @@ where
     /// Method to remove a service for a whole processor from the main bus
     pub async fn rm_service_proc(&self, names: Vec<String>, proc_id: u32) -> Result<(), BusError> {
         self.internal_tx_queue
-            .send(InternalMainMsg::DELPROCSRV(names, proc_id))
+            .send(InternalMainMsg::DeleteProcService(names, proc_id))
             .await
             .map_err(|e| {
                 BusError::InternalMainQueueError("DELPROCSRV".into(), proc_id, e.to_string())
@@ -210,7 +210,7 @@ where
         queue_id: u32,
     ) -> Result<(), BusError> {
         self.internal_tx_queue
-            .send(InternalMainMsg::DELSRV(names, proc_id, queue_id))
+            .send(InternalMainMsg::DeleteService(names, proc_id, queue_id))
             .await
             .map_err(|e| BusError::InternalMainQueueError("DELSRV".into(), proc_id, e.to_string()))
     }
@@ -218,7 +218,7 @@ where
     /// Method to stop all processors
     pub async fn stop(&self, reason: String) -> Result<(), BusError> {
         self.internal_tx_queue
-            .send(InternalMainMsg::SHUTDOWN(reason))
+            .send(InternalMainMsg::Shutdown(reason))
             .await
             .map_err(|e| BusError::InternalMainQueueError("SHUTDOWN".into(), 0, e.to_string()))
     }
@@ -309,7 +309,7 @@ where
             for proc_service in proc.values() {
                 if let Err(e) = proc_service
                     .proc_queue
-                    .send(InternalMsg::SERVICE(self.services.clone()))
+                    .send(InternalMsg::Service(self.services.clone()))
                     .await
                 {
                     // FIXME match the error. If it's a capacity error, don't drop the processor do something else
@@ -348,7 +348,7 @@ where
         let mut is_stopped = true;
         for proc in self.processors.values() {
             for proc_service in proc.values() {
-                if let Err(e) = proc_service.proc_queue.send(InternalMsg::SHUTDOWN).await {
+                if let Err(e) = proc_service.proc_queue.send(InternalMsg::Shutdown).await {
                     debug!("The {:?} seems already stopped: {}", proc_service, e);
                 } else {
                     is_stopped = false;
@@ -364,7 +364,7 @@ where
             tokio::select! {
                 Some(msg) = self.internal_rx_queue.recv() => {
                     match msg {
-                        InternalMainMsg::NEWPROCQUEUE(proc) => {
+                        InternalMainMsg::NewProcQueue(proc) => {
                             let proc_id = proc.get_proc_id();
                             let queue_id = proc.get_queue_id();
                             let proc_queue = proc.proc_queue.clone();
@@ -377,7 +377,7 @@ where
                             }
 
                             // Ask to the processor to load the service table
-                            if proc_queue.send(InternalMsg::SERVICE(self.services.clone())).await.is_err() {
+                            if proc_queue.send(InternalMsg::Service(self.services.clone())).await.is_err() {
                                 if let Some(proc_service) = self.processors.get_mut(&proc_id) {
                                     let _ = proc_service.remove(&queue_id);
                                 } else {
@@ -385,17 +385,17 @@ where
                                 }
                             }
                         },
-                        InternalMainMsg::DELPROC(proc_id) => {
+                        InternalMainMsg::DeleteProc(proc_id) => {
                             if self.remove_proc(proc_id).await.is_some() {
                                 prosa_main_update_srv!(self);
                             }
                         },
-                        InternalMainMsg::DELPROCQUEUE(proc_id, queue_id) => {
+                        InternalMainMsg::DeleteProcQueue(proc_id, queue_id) => {
                             if self.remove_proc_queue(proc_id, queue_id).await.is_some() {
                                 self.notify_srv_proc().await;
                             }
                         },
-                        InternalMainMsg::NEWPROCSRV(names, proc_id) => {
+                        InternalMainMsg::NewProcService(names, proc_id) => {
                             if let Some(proc_service) = self.processors.get(&proc_id) {
                                 let mut new_services = (*self.services).clone();
                                 for proc_queue in proc_service.values() {
@@ -407,7 +407,7 @@ where
                                 self.notify_srv_proc().await;
                             }
                         },
-                        InternalMainMsg::NEWSRV(names, proc_id, queue_id) => {
+                        InternalMainMsg::NewService(names, proc_id, queue_id) => {
                             if let Some(proc) = self.processors.get(&proc_id) {
                                 if let Some(proc_queue) = proc.get(&queue_id) {
                                     let mut new_services = (*self.services).clone();
@@ -419,7 +419,7 @@ where
                                 }
                             }
                         },
-                        InternalMainMsg::DELPROCSRV(names, proc_id) => {
+                        InternalMainMsg::DeleteProcService(names, proc_id) => {
                             let mut new_services = (*self.services).clone();
                             for name in names {
                                 new_services.rm_service_proc(&name, proc_id);
@@ -427,7 +427,7 @@ where
                             self.services = Arc::new(new_services);
                             self.notify_srv_proc().await;
                         },
-                        InternalMainMsg::DELSRV(names, proc_id, queue_id) => {
+                        InternalMainMsg::DeleteService(names, proc_id, queue_id) => {
                             let mut new_services = (*self.services).clone();
                             for name in names {
                                 new_services.rm_service(&name, proc_id, queue_id);
@@ -435,10 +435,10 @@ where
                             self.services = Arc::new(new_services);
                             self.notify_srv_proc().await;
                         },
-                        InternalMainMsg::COMMAND(cmd)=> {
+                        InternalMainMsg::Command(cmd)=> {
                             info!("Wan't to execute the command {}", cmd);
                         },
-                        InternalMainMsg::SHUTDOWN(reason) => {
+                        InternalMainMsg::Shutdown(reason) => {
                             warn!("ProSA need to stop: {}", reason);
                             self.stop().await;
 

--- a/prosa/src/core/msg.rs
+++ b/prosa/src/core/msg.rs
@@ -17,23 +17,23 @@ where
     M: Sized + Clone + Tvf,
 {
     /// Message to register a new spawned processor queue
-    NEWPROCQUEUE(ProcService<M>),
+    NewProcQueue(ProcService<M>),
     /// Message to indicate that a the processor stopped, delete all processor queues
-    DELPROC(u32),
+    DeleteProc(u32),
     /// Message to indicate that a the processor queue stopped, delete the processor queue
-    DELPROCQUEUE(u32, u32),
+    DeleteProcQueue(u32, u32),
     /// Message to declare new service(s) with their service name and the processor id (the processor should have been declared). Declare service(s) for the whole processor
-    NEWPROCSRV(Vec<String>, u32),
+    NewProcService(Vec<String>, u32),
     /// Message to declare new service(s) with their service name, the processor id (the processor should have been declared), and the queue id
-    NEWSRV(Vec<String>, u32, u32),
+    NewService(Vec<String>, u32, u32),
     /// Message to unregister a service for all the processor. Message that contain the service name and the processor id
-    DELPROCSRV(Vec<String>, u32),
+    DeleteProcService(Vec<String>, u32),
     /// Message to unregister service(s) for a processor queue. Message that contain service(s) name(s), the processor id, and the queue id
-    DELSRV(Vec<String>, u32, u32),
+    DeleteService(Vec<String>, u32, u32),
     /// Command to ask an action or a status to the main processor
-    COMMAND(String),
+    Command(String),
     /// Internal call for shutdown (with a reason)
-    SHUTDOWN(String),
+    Shutdown(String),
 }
 
 /// Internal ProSA message that define all message type that can be received by a processor
@@ -43,19 +43,19 @@ where
     M: Sized + Clone + Tvf,
 {
     /// Request Data message to process
-    REQUEST(RequestMsg<M>),
+    Request(RequestMsg<M>),
     /// Response of a data request message
-    RESPONSE(ResponseMsg<M>),
+    Response(ResponseMsg<M>),
     /// Response of a data request message by an error
-    ERROR(ErrorMsg<M>),
+    Error(ErrorMsg<M>),
     /// Command to ask an actiion or a status to the processor
-    COMMAND(String),
+    Command(String),
     /// Message to ask the processor to reload its configuration
-    CONFIG,
+    Config,
     /// Message to ask the processor to reload its service table
-    SERVICE(Arc<ServiceTable<M>>),
+    Service(Arc<ServiceTable<M>>),
     /// Message to ask the processor to shutdown
-    SHUTDOWN,
+    Shutdown,
 }
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
@@ -172,7 +172,7 @@ where
         resp: M,
     ) -> Result<(), tokio::sync::mpsc::error::SendError<InternalMsg<M>>> {
         self.response_queue
-            .send(InternalMsg::RESPONSE(ResponseMsg {
+            .send(InternalMsg::Response(ResponseMsg {
                 id: self.id,
                 service: self.service,
                 span: self.span,
@@ -190,7 +190,7 @@ where
         err: ServiceError,
     ) -> Result<(), tokio::sync::mpsc::error::SendError<InternalMsg<M>>> {
         self.response_queue
-            .send(InternalMsg::ERROR(ErrorMsg {
+            .send(InternalMsg::Error(ErrorMsg {
                 id: self.id,
                 service: self.service,
                 span: self.span,

--- a/prosa/src/core/proc.rs
+++ b/prosa/src/core/proc.rs
@@ -116,25 +116,25 @@
 //!         loop {
 //!             if let Some(msg) = self.internal_rx_queue.recv().await {
 //!                 match msg {
-//!                     InternalMsg::REQUEST(msg) => {
+//!                     InternalMsg::Request(msg) => {
 //!                         // Send the request to your adaptor and get a TVF object in return to respond to the sender
 //!                         let tvf = adaptor.process_request(msg.get_service(), msg.get_data());
 //!                         msg.return_to_sender(tvf).await.unwrap()
 //!                     }
-//!                     InternalMsg::RESPONSE(msg) => panic!(
+//!                     InternalMsg::Response(msg) => panic!(
 //!                         "The stub processor {} receive a response {:?}",
 //!                         self.get_proc_id(),
 //!                         msg
 //!                     ),
-//!                     InternalMsg::ERROR(err) => panic!(
+//!                     InternalMsg::Error(err) => panic!(
 //!                         "The stub processor {} receive an error {:?}",
 //!                         self.get_proc_id(),
 //!                         err
 //!                     ),
-//!                     InternalMsg::COMMAND(_) => todo!(),
-//!                     InternalMsg::CONFIG => todo!(),
-//!                     InternalMsg::SERVICE(table) => self.service = table,
-//!                     InternalMsg::SHUTDOWN => {
+//!                     InternalMsg::Command(_) => todo!(),
+//!                     InternalMsg::Config => todo!(),
+//!                     InternalMsg::Service(table) => self.service = table,
+//!                     InternalMsg::Shutdown => {
 //!                         adaptor.terminate();
 //!                         self.proc.rm_proc().await?;
 //!                         return Ok(());

--- a/prosa/src/core/proc.rs
+++ b/prosa/src/core/proc.rs
@@ -394,7 +394,7 @@ where
 /// ```
 pub trait Proc<A>
 where
-    A: Default + Adaptor,
+    A: Adaptor,
 {
     /// Main loop of the processor
     fn internal_run(
@@ -410,7 +410,7 @@ where
     ///
     /// fn routine<A, P>(proc: P)
     /// where
-    ///     A: Default + Adaptor,
+    ///     A: Adaptor,
     ///     P: Proc<A> + std::marker::Send + 'static,
     /// {
     ///     Proc::<A>::run(proc, String::from("processor_name"));

--- a/prosa/src/core/proc.rs
+++ b/prosa/src/core/proc.rs
@@ -27,12 +27,12 @@
 //! {
 //!     /// Method called when the processor spawns
 //!     /// This method is called only once so the processing will be thread safe
-//!     fn init(&mut self, proc: &MyProc<M>) -> Result<(), Box<dyn Error>>;
+//!     fn new(proc: &MyProc<M>) -> Result<Self, Box<dyn Error>> where Self: Sized;
 //!     /// Method to process incomming requests
 //!     fn process_request(&self, service_name: &str, request: &M) -> M;
 //! }
 //!
-//! #[derive(Default, Adaptor)]
+//! #[derive(Adaptor)]
 //! pub struct MyAdaptor {
 //!     // your adaptor vars here
 //! }
@@ -48,9 +48,9 @@
 //!     + prosa_utils::msg::tvf::Tvf
 //!     + std::default::Default,
 //! {
-//!     fn init(&mut self, proc: &MyProc<M>) -> Result<(), Box<dyn Error>> {
+//!     fn new(proc: &MyProc<M>) -> Result<Self, Box<dyn Error>> {
 //!         // Init your adaptor from processor parameters
-//!         Ok(())
+//!         Ok(Self {})
 //!     }
 //!
 //!     fn process_request(&self, service_name: &str, request: &M) -> M {
@@ -98,12 +98,11 @@
 //! #[proc]
 //! impl<A> Proc<A> for MyProc
 //! where
-//!     A: Default + Adaptor + MyAdaptorTrait<M> + std::marker::Send + std::marker::Sync,
+//!     A: Adaptor + MyAdaptorTrait<M> + std::marker::Send + std::marker::Sync,
 //! {
 //!     async fn internal_run(&mut self, name: String) -> Result<(), Box<dyn std::error::Error>> {
 //!         // Initiate an adaptor for the stub processor
-//!         let mut adaptor = A::default();
-//!         adaptor.init(self)?;
+//!         let mut adaptor = A::new(self)?;
 //!
 //!         // Declare the processor
 //!         self.proc.add_proc().await?;

--- a/prosa/src/event/pending.rs
+++ b/prosa/src/event/pending.rs
@@ -182,11 +182,11 @@ where
 ///     tokio::select! {
 ///         Some(msg) = queue.recv() => {
 ///             match msg {
-///                 InternalMsg::REQUEST(msg) => {
+///                 InternalMsg::Request(msg) => {
 ///                     // Push in the pending message, the message will wait a timeout of 200ms
 ///                     pending_msg.push(msg, Duration::from_millis(200));
 ///                 },
-///                 InternalMsg::RESPONSE(msg) => {
+///                 InternalMsg::Response(msg) => {
 ///                     let original_request: Option<RequestMsg<SimpleStringTvf>> = pending_msg.pull_msg(msg.get_id());
 ///                     println!("Receive a response: {:?}, from original request {:?}", msg, original_request);
 ///                 },
@@ -340,14 +340,14 @@ mod tests {
                 tokio::select! {
                     Some(msg) = self.internal_rx_queue.recv() => {
                         match msg {
-                            InternalMsg::REQUEST(_) => {
+                            InternalMsg::Request(_) => {
                                 assert_eq!(0, pending_timer.len());
                                 pending_timer.push(1, Duration::from_millis(100));
                                 assert_eq!(1, pending_timer.len());
                             },
-                            InternalMsg::SERVICE(table) => {
+                            InternalMsg::Service(table) => {
                                 if let Some(service) = table.get_proc_service(&String::from("TEST"), 1) {
-                                    service.proc_queue.send(InternalMsg::REQUEST(RequestMsg::new(1, String::from("TEST"), Default::default(), self.proc.get_service_queue().clone()))).await.unwrap();
+                                    service.proc_queue.send(InternalMsg::Request(RequestMsg::new(1, String::from("TEST"), Default::default(), self.proc.get_service_queue().clone()))).await.unwrap();
                                 }
                             },
                             _ => return Err(BusError::ProcCommError(self.get_proc_id(), 0, String::from("Wrong message"))),
@@ -376,16 +376,16 @@ mod tests {
                 tokio::select! {
                     Some(msg) = self.internal_rx_queue.recv() => {
                         match msg {
-                            InternalMsg::REQUEST(msg) => {
+                            InternalMsg::Request(msg) => {
                                 assert_eq!(0, pending_msg.len());
                                 pending_msg.push(msg, Duration::from_millis(100));
                                 assert_eq!(1, pending_msg.len());
                             },
-                            InternalMsg::SERVICE(table) => {
+                            InternalMsg::Service(table) => {
                                 if let Some(service) = table.get_proc_service(&String::from("TEST"), 1) {
                                     let mut msg: SimpleStringTvf = Default::default();
                                     msg.put_string(1, "good");
-                                    service.proc_queue.send(InternalMsg::REQUEST(RequestMsg::new(1, String::from("TEST"), msg, self.proc.get_service_queue().clone()))).await.unwrap();
+                                    service.proc_queue.send(InternalMsg::Request(RequestMsg::new(1, String::from("TEST"), msg, self.proc.get_service_queue().clone()))).await.unwrap();
                                 }
                             },
                             _ => return Err(BusError::ProcCommError(self.get_proc_id(), 0, String::from("Wrong message"))),

--- a/prosa/src/event/speed.rs
+++ b/prosa/src/event/speed.rs
@@ -360,6 +360,7 @@ mod tests {
         assert!(duration.as_millis() <= 4);
     }
 
+    #[allow(clippy::needless_return)]
     #[tokio::test]
     async fn regulator_test() {
         let mut regulator = Regulator::new(TPS, Duration::from_secs(3), 1, 5);

--- a/prosa/src/inj/adaptor.rs
+++ b/prosa/src/inj/adaptor.rs
@@ -14,7 +14,7 @@ extern crate self as prosa;
 /// use prosa::core::adaptor::Adaptor;
 /// use prosa::inj::adaptor::InjAdaptor;
 ///
-/// #[derive(Default, Adaptor)]
+/// #[derive(Adaptor)]
 /// pub struct MyInjAdaptor { }
 ///
 /// impl<M> InjAdaptor<M> for MyInjAdaptor
@@ -28,8 +28,8 @@ extern crate self as prosa;
 ///         + prosa_utils::msg::tvf::Tvf
 ///         + std::default::Default,
 /// {
-///     fn init(&mut self, _proc: &InjProc<M>) -> Result<(), Box<dyn std::error::Error>> {
-///         Ok(())
+///     fn new(_proc: &InjProc<M>) -> Result<Self, Box<dyn std::error::Error>> {
+///         Ok(Self {})
 ///     }
 ///     fn build_transaction(&mut self) -> M {
 ///         let mut msg = M::default();
@@ -51,7 +51,9 @@ where
 {
     /// Method called when the processor spawns
     /// This method is called only once so the processing will be thread safe
-    fn init(&mut self, proc: &InjProc<M>) -> Result<(), Box<dyn Error>>;
+    fn new(proc: &InjProc<M>) -> Result<Self, Box<dyn Error>>
+    where
+        Self: Sized;
     /// Method to build a transaction to inject
     fn build_transaction(&mut self) -> M;
     /// Method to process transaction response of the injection (to check the return code for example)
@@ -67,7 +69,7 @@ where
 }
 
 /// Dummy adaptor for the inj processor. Use to send a very basic message with _DUMMY_ in it.
-#[derive(Default, Adaptor)]
+#[derive(Adaptor)]
 pub struct InjDummyAdaptor {}
 
 impl<M> InjAdaptor<M> for InjDummyAdaptor
@@ -81,8 +83,8 @@ where
         + prosa_utils::msg::tvf::Tvf
         + std::default::Default,
 {
-    fn init(&mut self, _proc: &InjProc<M>) -> Result<(), Box<dyn Error>> {
-        Ok(())
+    fn new(_proc: &InjProc<M>) -> Result<Self, Box<dyn Error>> {
+        Ok(Self {})
     }
 
     fn build_transaction(&mut self) -> M {

--- a/prosa/src/inj/proc.rs
+++ b/prosa/src/inj/proc.rs
@@ -133,7 +133,7 @@ impl InjProc {
         meter_trans_duration: &Histogram<f64>,
     ) -> Result<(), Box<dyn std::error::Error>>
     where
-        A: Default + Adaptor + InjAdaptor<M> + std::marker::Send + std::marker::Sync,
+        A: Adaptor + InjAdaptor<M> + std::marker::Send + std::marker::Sync,
     {
         match msg {
             InternalMsg::Request(msg) => panic!(
@@ -181,12 +181,11 @@ impl InjProc {
 #[proc]
 impl<A> Proc<A> for InjProc
 where
-    A: Default + Adaptor + InjAdaptor<M> + std::marker::Send + std::marker::Sync,
+    A: Adaptor + InjAdaptor<M> + std::marker::Send + std::marker::Sync,
 {
     async fn internal_run(&mut self, name: String) -> Result<(), Box<dyn std::error::Error>> {
         // Initiate an adaptor for the inj processor
-        let mut adaptor = A::default();
-        adaptor.init(self)?;
+        let mut adaptor = A::new(self)?;
 
         // meter
         let meter = self.proc.meter(name.clone());

--- a/prosa/src/inj/proc.rs
+++ b/prosa/src/inj/proc.rs
@@ -136,12 +136,12 @@ impl InjProc {
         A: Default + Adaptor + InjAdaptor<M> + std::marker::Send + std::marker::Sync,
     {
         match msg {
-            InternalMsg::REQUEST(msg) => panic!(
+            InternalMsg::Request(msg) => panic!(
                 "The inj processor {} receive a request {:?}",
                 self.get_proc_id(),
                 msg
             ),
-            InternalMsg::RESPONSE(msg) => {
+            InternalMsg::Response(msg) => {
                 let _enter_span = msg.enter_span();
                 meter_trans_duration.record(
                     msg.elapsed().as_secs_f64(),
@@ -159,15 +159,15 @@ impl InjProc {
                 // Build the next transaction
                 let _ = next_transaction.get_or_insert(adaptor.build_transaction());
             }
-            InternalMsg::ERROR(err) => panic!(
+            InternalMsg::Error(err) => panic!(
                 "The inj processor {} receive an error {:?}",
                 self.get_proc_id(),
                 err
             ),
-            InternalMsg::COMMAND(_) => todo!(),
-            InternalMsg::CONFIG => todo!(),
-            InternalMsg::SERVICE(table) => self.service = table,
-            InternalMsg::SHUTDOWN => {
+            InternalMsg::Command(_) => todo!(),
+            InternalMsg::Config => todo!(),
+            InternalMsg::Service(table) => self.service = table,
+            InternalMsg::Shutdown => {
                 adaptor.terminate();
                 self.proc.rm_proc().await?;
                 return Ok(());
@@ -224,7 +224,7 @@ where
             .get_proc_service(&self.settings.service_name, msg_id)
             .unwrap()
             .proc_queue
-            .send(InternalMsg::REQUEST(RequestMsg::new(
+            .send(InternalMsg::Request(RequestMsg::new(
                 msg_id,
                 self.settings.service_name.clone(),
                 next_transaction.take().unwrap(),
@@ -248,7 +248,7 @@ where
                         };
 
                         debug!(name: "inj_proc", target: "prosa::inj::proc", parent: trans.get_span(), proc_name = name, service = self.settings.service_name, request = format!("{:?}", trans.get_data()));
-                        service.proc_queue.send(InternalMsg::REQUEST(trans)).await?;
+                        service.proc_queue.send(InternalMsg::Request(trans)).await?;
 
                         msg_id += 1;
                         regulator.notify_send_transaction();

--- a/prosa/src/lib.rs
+++ b/prosa/src/lib.rs
@@ -96,6 +96,7 @@ mod tests {
     }
 
     /// Test a ProSA with an injector processor sending transactions to a stub processor
+    #[allow(clippy::needless_return)]
     #[tokio::test]
     async fn prosa() {
         let test_settings = TestSettings::new(SERVICE_TEST);

--- a/prosa/src/lib.rs
+++ b/prosa/src/lib.rs
@@ -67,7 +67,7 @@ mod tests {
         }
     }
 
-    #[derive(Default, Adaptor)]
+    #[derive(Adaptor)]
     struct TestStubAdaptor {
         msg_count: u32,
     }
@@ -83,8 +83,8 @@ mod tests {
             + prosa_utils::msg::tvf::Tvf
             + std::default::Default,
     {
-        fn init(&mut self, _proc: &StubProc<M>) -> Result<(), Box<dyn Error>> {
-            Ok(())
+        fn new(_proc: &StubProc<M>) -> Result<Self, Box<dyn Error>> {
+            Ok(Self { msg_count: 0 })
         }
 
         fn process_request(&mut self, _service_name: &str, request: &M) -> M {

--- a/prosa/src/stub/adaptor.rs
+++ b/prosa/src/stub/adaptor.rs
@@ -6,8 +6,7 @@ use super::proc::StubProc;
 
 extern crate self as prosa;
 
-use opentelemetry::metrics::{Meter, MeterProvider as _};
-use opentelemetry_sdk::metrics::MeterProvider;
+use opentelemetry::metrics::Meter;
 
 /// Adaptator trait for the stub processor
 ///
@@ -17,7 +16,7 @@ use opentelemetry_sdk::metrics::MeterProvider;
 /// use prosa::core::adaptor::Adaptor;
 /// use prosa::stub::adaptor::StubAdaptor;
 ///
-/// #[derive(Default, Adaptor)]
+/// #[derive(Adaptor)]
 /// pub struct MyStubAdaptor { }
 ///
 /// impl<M> StubAdaptor<M> for MyStubAdaptor
@@ -31,8 +30,8 @@ use opentelemetry_sdk::metrics::MeterProvider;
 ///         + prosa_utils::msg::tvf::Tvf
 ///         + std::default::Default,
 /// {
-///     fn init(&mut self, _proc: &StubProc<M>) -> Result<(), Box<dyn std::error::Error>> {
-///         Ok(())
+///     fn new(_proc: &StubProc<M>) -> Result<Self, Box<dyn std::error::Error>> {
+///         Ok(Self {})
 ///     }
 ///     fn process_request(&mut self, service_name: &str, request: &M) -> M {
 ///         let mut msg = request.clone();
@@ -54,7 +53,9 @@ where
 {
     /// Method called when the processor spawns
     /// This method is called only once so the processing will be thread safe
-    fn init(&mut self, proc: &StubProc<M>) -> Result<(), Box<dyn Error>>;
+    fn new(proc: &StubProc<M>) -> Result<Self, Box<dyn Error>>
+    where
+        Self: Sized;
     /// Method to process incomming requests
     fn process_request(&mut self, service_name: &str, request: &M) -> M;
 }
@@ -62,6 +63,7 @@ where
 /// Parot adaptor for the stub processor. Use to respond to a request with the same message
 #[derive(Adaptor)]
 pub struct StubParotAdaptor {
+    #[allow(unused)]
     meter: Meter,
 }
 
@@ -76,20 +78,13 @@ where
         + prosa_utils::msg::tvf::Tvf
         + std::default::Default,
 {
-    fn init(&mut self, proc: &StubProc<M>) -> Result<(), Box<dyn Error>> {
-        self.meter = proc.get_proc_param().meter("stub_adaptor");
-        Ok(())
+    fn new(proc: &StubProc<M>) -> Result<Self, Box<dyn Error>> {
+        Ok(Self {
+            meter: proc.get_proc_param().meter("stub_adaptor"),
+        })
     }
 
     fn process_request(&mut self, _service_name: &str, request: &M) -> M {
         request.clone()
-    }
-}
-
-impl Default for StubParotAdaptor {
-    fn default() -> Self {
-        Self {
-            meter: MeterProvider::default().meter("prosa_parot"),
-        }
     }
 }

--- a/prosa/src/stub/proc.rs
+++ b/prosa/src/stub/proc.rs
@@ -88,25 +88,25 @@ where
         loop {
             if let Some(msg) = self.internal_rx_queue.recv().await {
                 match msg {
-                    InternalMsg::REQUEST(msg) => {
+                    InternalMsg::Request(msg) => {
                         let resp_data = adaptor.process_request(msg.get_service(), msg.get_data());
                         debug!(name: "stub_proc", target: "prosa::stub::proc", parent: msg.get_span(), proc_name = name, stub_service = msg.get_service(), stub_req = format!("{:?}", msg.get_data()).to_string(), stub_resp = format!("{:?}", resp_data));
                         msg.return_to_sender(resp_data).await.unwrap()
                     }
-                    InternalMsg::RESPONSE(msg) => panic!(
+                    InternalMsg::Response(msg) => panic!(
                         "The stub processor {} receive a response {:?}",
                         self.get_proc_id(),
                         msg
                     ),
-                    InternalMsg::ERROR(err) => panic!(
+                    InternalMsg::Error(err) => panic!(
                         "The stub processor {} receive an error {:?}",
                         self.get_proc_id(),
                         err
                     ),
-                    InternalMsg::COMMAND(_) => todo!(),
-                    InternalMsg::CONFIG => todo!(),
-                    InternalMsg::SERVICE(table) => self.service = table,
-                    InternalMsg::SHUTDOWN => {
+                    InternalMsg::Command(_) => todo!(),
+                    InternalMsg::Config => todo!(),
+                    InternalMsg::Service(table) => self.service = table,
+                    InternalMsg::Shutdown => {
                         adaptor.terminate();
                         self.proc.rm_proc().await?;
                         return Ok(());

--- a/prosa/src/stub/proc.rs
+++ b/prosa/src/stub/proc.rs
@@ -70,12 +70,11 @@ pub struct StubProc {}
 #[proc]
 impl<A> Proc<A> for StubProc
 where
-    A: Default + Adaptor + StubAdaptor<M> + std::marker::Send + std::marker::Sync,
+    A: Adaptor + StubAdaptor<M> + std::marker::Send + std::marker::Sync,
 {
     async fn internal_run(&mut self, name: String) -> Result<(), Box<dyn std::error::Error>> {
         // Initiate an adaptor for the stub processor
-        let mut adaptor = A::default();
-        adaptor.init(self)?;
+        let mut adaptor = A::new(self)?;
 
         // Declare the processor
         self.proc.add_proc().await?;


### PR DESCRIPTION
Removed the `Default` trait requirement for the `Adaptor` trait such that adaptors can be instantiated with embedded data.
Renamed multiple enum variants from capital case to pascal casee to follow Rust coding convention.
Introduced a `Id` alias type for TVF fields' identifiers.