### PR TITLE
fix: Correct CI pipeline with new licence for deny and unit/doc test

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,7 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "Unicode-DFS-2016",
+    "Unicode-3.0",
     "LGPL-3.0",
 ]
 confidence-threshold = 0.8

--- a/prosa_utils/src/config/observability.rs
+++ b/prosa_utils/src/config/observability.rs
@@ -294,15 +294,8 @@ impl Default for TelemetryData {
 ///     let observability_settings = Observability::default();
 ///
 ///     // trace
-///     //global::set_tracer_provider(observability_settings.build_tracer_provider());
 ///     let filter = TelemetryFilter::default();
 ///     observability_settings.tracing_init(&filter);
-///
-///     // meter
-///     global::set_meter_provider(observability_settings.build_meter_provider());
-///
-///     // logger
-///     global::set_logger_provider(observability_settings.build_logger_provider());
 /// }
 /// ```
 #[derive(Debug, Deserialize, Serialize, Clone)]


### PR DESCRIPTION
- The deny throw an error in the CI because the _Unicode-3.0_ licence is not in the list.
- Observability doc don't compil because legacy function were use for Opentelemetry.
- Speed object/test was improved to use only Tokio sleep and to improved reliability on MacOS systems.