### PR TITLE
fix: version before release 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 ]
 
 [workspace.dependencies]
-prosa-utils = { version = "0.1.1", path = "prosa_utils" }
+prosa-utils = { version = "0.1.2", path = "prosa_utils" }
 prosa-macros = { version = "0.1.2", path = "prosa_macros" }
 thiserror = "1"
 aquamarine = "0.5"


### PR DESCRIPTION
The version was wrong in the top _Cargo.toml_ file. Correct it before making the 0.1.2 release.