### PR TITLE
feat: Improve global compilation time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ prosa-macros = { version = "0.1.2", path = "prosa_macros" }
 thiserror = "2"
 aquamarine = "0.6"
 bytes = "1"
+chrono = "0.4"
 url = { version = "2", features = ["serde"] }
 tokio = { version = "1", features = ["fs", "macros", "net", "parking_lot", "rt", "rt-multi-thread", "signal", "sync", "time"] }
 config = { version = "0.15", default-features = false, features = ["toml", "json", "yaml", "json5", "convert-case", "async"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,13 @@ include = [
 [workspace.dependencies]
 prosa-utils = { version = "0.1.2", path = "prosa_utils" }
 prosa-macros = { version = "0.1.2", path = "prosa_macros" }
-thiserror = "1"
-aquamarine = "0.5"
+thiserror = "2"
+aquamarine = "0.6"
 bytes = "1"
 url = { version = "2", features = ["serde"] }
-tokio = "1"
+tokio = { version = "1", features = ["fs", "macros", "net", "parking_lot", "rt", "rt-multi-thread", "signal", "sync", "time"] }
+config = { version = "0.15", default-features = false, features = ["toml", "json", "yaml", "json5", "convert-case", "async"] }
+toml = "0.8"
 
 # Config Observability
 log = "0.4"

--- a/cargo-prosa/Cargo.toml
+++ b/cargo-prosa/Cargo.toml
@@ -14,20 +14,18 @@ name = "cargo-prosa"
 path = "src/main.rs"
 
 [dependencies]
-bytes.workspace = true
 thiserror.workspace = true
 prosa-utils = { workspace = true, features = ["msg", "config", "config-observability"] }
 aquamarine.workspace = true
-clap = { version = "4", features = ["derive"] }
+clap = "4"
 clap_complete = "4"
 serde = "1"
-toml = "0.8"
+toml.workspace = true
 toml_edit = { version = "0.22", features = ["serde"] }
 serde_json = "1"
 serde_yaml = "0.9"
-config = "0.13"
+config.workspace = true
 tera = "1"
-daemonize = "0.5"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/cargo-prosa/assets/build.rs.j2
+++ b/cargo-prosa/assets/build.rs.j2
@@ -11,7 +11,7 @@ use cargo_prosa::CONFIGURATION_FILENAME;
 use cargo_prosa::package::deb::DebPkg;
 {% endif %}
 
-fn write_settings_rs(out_dir: &OsString, desc: &Desc, metadata: &HashMap<String, Metadata>) -> io::Result<()> {{ '{' }}
+fn write_settings_rs(out_dir: &OsString, desc: &Desc, metadata: &HashMap<&str, Metadata>) -> io::Result<()> {{ '{' }}
     let mut f = fs::File::create(Path::new(&out_dir).join("settings.rs"))?;
     writeln!(f, "use prosa::core::settings::settings;")?;
 
@@ -21,7 +21,7 @@ fn write_settings_rs(out_dir: &OsString, desc: &Desc, metadata: &HashMap<String,
         writeln!(f, "#[derive(Default, Debug, Deserialize, Serialize)]")?;
         writeln!(f, "pub struct RunSettings {{ '{{' }}")?;
         for processor in processors {{ '{' }}
-            let proc_metadata = metadata.get(&processor.proc_name).unwrap_or_else(|| panic!("Can't get the processor {{ '{}' }} metadata ({{ '{:?}' }})", processor.proc, processor.name));
+            let proc_metadata = metadata.get(processor.proc_name.as_str()).unwrap_or_else(|| panic!("Can't get the processor {{ '{}' }} metadata ({{ '{:?}' }})", processor.proc, processor.name));
             if let Some(settings) = &proc_metadata.settings {{ '{' }}
                 if let Some(description) = &proc_metadata.description {{ '{' }}
                     writeln!(f, "    /// {{ '{}' }}", description)?;
@@ -100,7 +100,7 @@ fn write_config_rs(out_dir: &OsString, desc: &Desc, cargo_metadata: &CargoMetada
     writeln!(f, "{{ '}}' }}\n")
 {{ '}' }}
 
-fn write_run_rs(out_dir: &OsString, desc: &Desc, metadata: &HashMap<String, Metadata>) -> io::Result<()> {{ '{' }}
+fn write_run_rs(out_dir: &OsString, desc: &Desc, metadata: &HashMap<&str, Metadata>) -> io::Result<()> {{ '{' }}
     let mut f = fs::File::create(Path::new(&out_dir).join("run.rs"))?;
 
     writeln!(f, "fn new_main(settings: &RunSettings) -> (prosa::core::main::Main<{{ '{}' }}>, {{ '{}' }}<{{ '{}' }}>) {{ '{{' }}", desc.prosa.tvf, desc.prosa.main, desc.prosa.tvf)?;
@@ -115,7 +115,7 @@ fn write_run_rs(out_dir: &OsString, desc: &Desc, metadata: &HashMap<String, Meta
         for processor in processors {{ '{' }}
             proc_id += 1;
             writeln!(f, "debug!(\"Start processor {{ '{}' }}\");", processor.get_name())?;
-            let proc_metadata = metadata.get(&processor.proc_name).unwrap_or_else(|| panic!("Can't get the processor {{ '{}' }} metadata ({{ '{:?}' }})", processor.proc, processor.name));
+            let proc_metadata = metadata.get(processor.proc_name.as_str()).unwrap_or_else(|| panic!("Can't get the processor {{ '{}' }} metadata ({{ '{:?}' }})", processor.proc, processor.name));
             if proc_metadata.settings.is_some() {{ '{' }}
                 writeln!(f, "let proc = {{ '{}' }}::<{{ '{}' }}>::create({{ '{}' }}, bus.clone(), settings.{{ '{}' }}.clone());", processor.proc, desc.prosa.tvf, proc_id, processor.get_name().replace('-', "_"))?;
             {{ '}' }} else {{ '{' }}
@@ -186,8 +186,8 @@ fn write_target_config(out_dir: &OsString, target_dir: &Path) -> io::Result<()> 
 
     // Correct relative path in the Cargo.toml by the `out_dir` one
     let cargo_content = fs::read_to_string("Cargo.toml")?.replace("\"../", format!("\"{}/../", env::current_dir()?.display()).as_str());
-    let mut cargo_dst = fs::File::create(&prosa_config_path.join("Cargo.toml"))?;
-    cargo_dst.write(cargo_content.as_bytes())?;
+    let mut cargo_dst = fs::File::create(prosa_config_path.join("Cargo.toml"))?;
+    cargo_dst.write_all(cargo_content.as_bytes())?;
 
     let mut f = fs::File::create(prosa_config_path.join("src").join("main.rs"))?;
     writeln!(f, "use prosa::core::settings::Settings;\n")?;

--- a/cargo-prosa/src/builder.rs
+++ b/cargo-prosa/src/builder.rs
@@ -194,13 +194,16 @@ impl Desc {
     where
         P: AsRef<Path>,
     {
-        let mut toml_file = fs::File::create(&path)?;
-        writeln!(toml_file, "# ProSA definition")?;
-        writeln!(
-            toml_file,
-            "{}",
-            toml::to_string(&self).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
-        )
+        fn inner(desc: &Desc, mut file: fs::File) -> Result<(), io::Error> {
+            writeln!(file, "# ProSA definition")?;
+            writeln!(
+                file,
+                "{}",
+                toml::to_string(&desc)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+            )
+        }
+        inner(self, fs::File::create(&path)?)
     }
 
     /// Method to read a ProSA toml description file

--- a/prosa/Cargo.toml
+++ b/prosa/Cargo.toml
@@ -28,9 +28,8 @@ adaptor = ["stub::adaptor::StubParotAdaptor"]
 
 [dependencies]
 prosa-utils = { workspace = true, features = ["msg", "config", "config-observability"] }
-prosa-macros = { workspace = true }
-bytes = {workspace = true}
-chrono = "0.4"
+prosa-macros.workspace = true
+bytes.workspace = true
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["std", "env-filter"]}
 thiserror.workspace = true

--- a/prosa/Cargo.toml
+++ b/prosa/Cargo.toml
@@ -30,7 +30,7 @@ adaptor = ["stub::adaptor::StubParotAdaptor"]
 prosa-utils = { workspace = true, features = ["msg", "config", "config-observability"] }
 prosa-macros = { workspace = true }
 bytes = {workspace = true}
-chrono= "0.4"
+chrono = "0.4"
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["std", "env-filter"]}
 thiserror.workspace = true
@@ -40,14 +40,14 @@ rlimit = "0.10"
 aquamarine.workspace = true
 
 openssl = { version = "0.10" }
-tokio = { workspace = true, features = ["full"] }
+tokio.workspace = true
 tokio-openssl = "0.6"
 async-http-proxy = { version = "1", features = ["runtime-tokio","basic-auth"] }
 
 serde = { version = "1", features = ["derive"] }
-config = "0.13"
+config.workspace = true
 glob = { version = "0.3" }
-toml = "0.8"
+toml.workspace = true
 serde_yaml = "0.9"
 
 log.workspace = true

--- a/prosa_macros/Cargo.toml
+++ b/prosa_macros/Cargo.toml
@@ -13,7 +13,7 @@ include.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = { version = "2", features = ["full", "extra-traits"] }
+syn = "2"
 quote = "1"
 proc-macro2 = "1"
 chrono = "0.4"

--- a/prosa_macros/Cargo.toml
+++ b/prosa_macros/Cargo.toml
@@ -16,8 +16,8 @@ proc-macro = true
 syn = "2"
 quote = "1"
 proc-macro2 = "1"
-chrono = "0.4"
+chrono.workspace = true
 
 [dev-dependencies]
-bytes = { workspace = true }
-prosa-utils = { workspace = true }
+bytes.workspace = true
+prosa-utils.workspace = true

--- a/prosa_utils/Cargo.toml
+++ b/prosa_utils/Cargo.toml
@@ -12,7 +12,7 @@ include.workspace = true
 [features]
 default = ["full"]
 msg = []
-config = ["dep:glob","dep:serde","dep:toml","dep:serde_yaml"]
+config = ["dep:glob","dep:serde","dep:serde_yaml"]
 config-openssl = ["config", "dep:openssl"]
 config-observability = ["dep:log", "dep:tracing-core", "dep:tracing-subscriber", "dep:tracing-opentelemetry", "dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-stdout", "dep:opentelemetry-otlp"]
 config-observability-prometheus = ["config-observability", "dep:prometheus", "dep:prometheus_exporter", "dep:opentelemetry-prometheus"]
@@ -31,7 +31,6 @@ hex = "0.4"
 # Config
 glob = { version = "0.3", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
-toml = { version = "0.8", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 
 # Config OpenSSL
@@ -51,5 +50,5 @@ prometheus_exporter = { workspace = true, optional = true }
 opentelemetry-prometheus = { workspace = true, optional = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full"] }
+tokio.workspace = true
 tokio-openssl = "0.6"

--- a/prosa_utils/Cargo.toml
+++ b/prosa_utils/Cargo.toml
@@ -25,7 +25,7 @@ tvf = ["msg::simple_string_tvf::SimpleStringTvf"]
 thiserror.workspace = true
 bytes.workspace = true
 url.workspace = true
-chrono = "0.4"
+chrono.workspace = true
 hex = "0.4"
 
 # Config


### PR DESCRIPTION
Review on all dependencies and features associated.

The goal was to do a cleaning of all non used package and reduce the amount of features use for each.

Thanks to that, we gain 10 secondes of compilation on a Raspberry Pi 4 from 8m27 to 8m17
Also save 7 seconds from a cargo-prosa package build (from 17m43 to 17m36)

This PR don't solve everything. next step will be #19