### PR TITLE
fix: Correct Tokio runtime for main() and Processors

### DIFF
--- a/cargo-prosa/assets/build.rs.j2
+++ b/cargo-prosa/assets/build.rs.j2
@@ -83,6 +83,7 @@ fn write_config_rs(out_dir: &OsString, desc: &Desc, cargo_metadata: &CargoMetada
     writeln!(f, "        .arg(::clap::arg!(-n --name <NAME> \"Name of the ProSA\"))")?;
     writeln!(f, "        .arg(::clap::arg!(--user <USER> \"User:Group to run the daemon ProSA\"))")?;
     writeln!(f, "        .arg(::clap::arg!(-l --log_path <LOGPATH> \"Path of the output log\"))")?;
+    writeln!(f, "        .arg(::clap::arg!(-t --worker_threads <THREADS> \"Number of worker threads to use for the main\").value_parser(clap::value_parser!(u32).range(1..)).default_value(\"1\"))")?;
     writeln!(f, "{{ '}}' }}\n")?;
 
     writeln!(f, "fn prosa_config(matches: &::clap::ArgMatches) -> Result<::config::Config, ::config::ConfigError> {{ '{{' }}")?;
@@ -122,7 +123,7 @@ fn write_run_rs(out_dir: &OsString, desc: &Desc, metadata: &HashMap<&str, Metada
                 writeln!(f, "    let proc = {{ '{}' }}::<{{ '{}' }}>::create_raw({{ '{}' }}, bus.clone());", processor.proc, desc.prosa.tvf, proc_id)?;
             {{ '}' }}
 
-            writeln!(f, "    prosa::core::proc::Proc::<{{ '{}' }}>::run(proc, settings.get_prosa_name());", processor.adaptor)?;
+            writeln!(f, "    prosa::core::proc::Proc::<{{ '{}' }}>::run(proc, String::from(\"{{ '{}' }}\"));", processor.adaptor, processor.get_name())?;
         {{ '}' }}
     {{ '}' }}
 

--- a/cargo-prosa/assets/build.rs.j2
+++ b/cargo-prosa/assets/build.rs.j2
@@ -114,15 +114,15 @@ fn write_run_rs(out_dir: &OsString, desc: &Desc, metadata: &HashMap<&str, Metada
     if let Some(processors) = &desc.proc {{ '{' }}
         for processor in processors {{ '{' }}
             proc_id += 1;
-            writeln!(f, "debug!(\"Start processor {{ '{}' }}\");", processor.get_name())?;
+            writeln!(f, "    debug!(\"Start processor {{ '{}' }}\");", processor.get_name())?;
             let proc_metadata = metadata.get(processor.proc_name.as_str()).unwrap_or_else(|| panic!("Can't get the processor {{ '{}' }} metadata ({{ '{:?}' }})", processor.proc, processor.name));
             if proc_metadata.settings.is_some() {{ '{' }}
-                writeln!(f, "let proc = {{ '{}' }}::<{{ '{}' }}>::create({{ '{}' }}, bus.clone(), settings.{{ '{}' }}.clone());", processor.proc, desc.prosa.tvf, proc_id, processor.get_name().replace('-', "_"))?;
+                writeln!(f, "    let proc = {{ '{}' }}::<{{ '{}' }}>::create({{ '{}' }}, bus.clone(), settings.{{ '{}' }}.clone());", processor.proc, desc.prosa.tvf, proc_id, processor.get_name().replace('-', "_"))?;
             {{ '}' }} else {{ '{' }}
-                writeln!(f, "let proc = {{ '{}' }}::<{{ '{}' }}>::create_raw({{ '{}' }}, bus.clone());", processor.proc, desc.prosa.tvf, proc_id)?;
+                writeln!(f, "    let proc = {{ '{}' }}::<{{ '{}' }}>::create_raw({{ '{}' }}, bus.clone());", processor.proc, desc.prosa.tvf, proc_id)?;
             {{ '}' }}
 
-            writeln!(f, "prosa::core::proc::Proc::<{{ '{}' }}>::run(proc, settings.get_prosa_name());", processor.adaptor)?;
+            writeln!(f, "    prosa::core::proc::Proc::<{{ '{}' }}>::run(proc, settings.get_prosa_name());", processor.adaptor)?;
         {{ '}' }}
     {{ '}' }}
 

--- a/cargo-prosa/assets/main.rs.j2
+++ b/cargo-prosa/assets/main.rs.j2
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {{ '{' }}
     prosa_main(matches)
 {{ '}' }}
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn prosa_main(matches: clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {{ '{' }}
     // Look if we have to launch the ProSA or just dry run
     if matches.get_flag("dry_run") {{ '{' }}
@@ -63,7 +63,6 @@ async fn prosa_main(matches: clap::ArgMatches) -> Result<(), Box<dyn std::error:
         let (bus, main) = new_main(&prosa_settings);
 
         // Launch the main task
-        debug!("Launch the main task");
         let main_task = main.run();
 
         // Run all processors

--- a/cargo-prosa/assets/main.rs.j2
+++ b/cargo-prosa/assets/main.rs.j2
@@ -4,6 +4,8 @@ use serde::{{ '{' }}Deserialize, Serialize{{ '}' }};
 
 use tracing::{{ '{' }}debug, info{{ '}' }};
 
+use tokio::runtime;
+
 use prosa_utils::config::tracing::TelemetryFilter;
 use prosa::core::main::MainRunnable;
 use prosa::core::settings::Settings;
@@ -26,10 +28,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {{ '{' }}
         daemonize(&matches);
     {{ '}' }}
 
-    prosa_main(matches)
+    // Main runtime
+    match matches.get_one::<u32>("worker_threads") {
+        Some(1) | None => runtime::Builder::new_current_thread()
+            .enable_all()
+            .thread_name("main")
+            .build(),
+        Some(n) => runtime::Builder::new_multi_thread()
+            .worker_threads(*n as usize)
+            .enable_all()
+            .thread_name("main")
+            .build(),
+    }
+    .unwrap()
+    .block_on(prosa_main(matches))
 {{ '}' }}
 
-#[tokio::main(flavor = "current_thread")]
 async fn prosa_main(matches: clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {{ '{' }}
     // Look if we have to launch the ProSA or just dry run
     if matches.get_flag("dry_run") {{ '{' }}
@@ -69,7 +83,7 @@ async fn prosa_main(matches: clap::ArgMatches) -> Result<(), Box<dyn std::error:
         run_processors(bus, &prosa_settings);
 
         // Wait on main task
-        main_task.join().unwrap();
+        main_task.await;
     {{ '}' }}
 
     Ok(())

--- a/prosa/examples/proc.rs
+++ b/prosa/examples/proc.rs
@@ -157,7 +157,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Proc::<MyAdaptor>::run(proc2, String::from("proc_2"));
 
     // Wait on main task
-    main_task.join().unwrap();
+    main_task.await;
     opentelemetry::global::shutdown_tracer_provider();
     Ok(())
 }

--- a/prosa/examples/proc.rs
+++ b/prosa/examples/proc.rs
@@ -137,9 +137,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create bus and main processor
     let (bus, main) = MainProc::<SimpleStringTvf>::create(&my_settings);
 
-    // Launch the main task
-    let main_task = main.run();
-
     // Launch a stub processor
     let stub_settings = StubSettings::new(vec![String::from("STUB_TEST")]);
     let stub_proc = StubProc::<SimpleStringTvf>::create(1, bus.clone(), stub_settings);
@@ -157,7 +154,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Proc::<MyAdaptor>::run(proc2, String::from("proc_2"));
 
     // Wait on main task
-    main_task.await;
+    main.run().await;
     opentelemetry::global::shutdown_tracer_provider();
     Ok(())
 }

--- a/prosa/src/core/main.rs
+++ b/prosa/src/core/main.rs
@@ -36,7 +36,7 @@ where
     /// Method to create and run the main task (must be called before processor creation)
     fn create<S: Settings>(settings: &S) -> (Main<M>, Self);
 
-    /// Method call to run the main task (must be called before processor creation)
+    /// Method call to run the main task (should be called before processor creation)
     fn run(self) -> std::thread::JoinHandle<()>;
 }
 
@@ -365,7 +365,7 @@ where
         is_stopped
     }
 
-    async fn internal_run(&mut self) -> Result<(), BusError> {
+    async fn internal_run(mut self) {
         // Monitor RAM usage
         let prosa_name = self.name.clone();
         self.meter
@@ -563,7 +563,7 @@ where
                             self.stop().await;
 
                             // The shutdown mecanism will be implemented later
-                            return Ok(())
+                            return;
                         },
                     }
                 },
@@ -572,7 +572,7 @@ where
                     self.stop().await;
 
                     // The shutdown mecanism will be implemented later
-                    return Ok(())
+                    return;
                 },
             }
         }
@@ -618,7 +618,7 @@ where
         inner(Main::new(internal_tx_queue, settings), internal_rx_queue)
     }
 
-    fn run(mut self) -> std::thread::JoinHandle<()> {
+    fn run(self) -> std::thread::JoinHandle<()> {
         std::thread::Builder::new()
             .name(MAIN_TASK_NAME.into())
             .spawn(move || {
@@ -627,7 +627,7 @@ where
                     .thread_name(MAIN_TASK_NAME)
                     .build()
                     .unwrap();
-                rt.block_on(self.internal_run()).unwrap();
+                rt.block_on(self.internal_run());
             })
             .unwrap()
     }

--- a/prosa/src/core/proc.rs
+++ b/prosa/src/core/proc.rs
@@ -156,9 +156,9 @@ use prosa_utils::msg::tvf::Tvf;
 use std::borrow::Cow;
 use std::fmt::Debug;
 use std::time::Duration;
-use tokio::runtime;
 use tokio::sync::mpsc;
 use tokio::time::sleep;
+use tokio::{runtime, spawn};
 
 // Export proc macro
 pub use prosa_macros::proc;
@@ -420,6 +420,68 @@ where
     fn get_proc_param(&self) -> &ProcParam<M>;
 }
 
+macro_rules! proc_run {
+    ( $self:ident, $proc_name:ident ) => {
+        info!(
+            "Run processor {} on {} threads",
+            $proc_name,
+            $self.get_proc_threads()
+        );
+
+        let proc_restart_delay = $self.get_proc_restart_delay();
+        let mut wait_time = proc_restart_delay.0;
+        loop {
+            if let Err(proc_err) = $self.internal_run($proc_name.clone()).await {
+                // Stop the processor immediately if ProSA is shutting down
+                if $self.is_stopping() {
+                    // Remove the proc from main
+                    let _ = $self.remove_proc(None).await;
+                    return;
+                }
+
+                let recovery_duration = proc_err.recovery_duration();
+
+                // Log and restart if needed
+                if proc_err.recoverable() {
+                    warn!(
+                        "Processor {} encounter an error `{}`. Will restart after {}ms",
+                        $proc_name,
+                        proc_err,
+                        (wait_time + recovery_duration).as_millis()
+                    );
+
+                    // Notify the main task of the error
+                    if $self.remove_proc(Some(proc_err)).await.is_err() {
+                        return;
+                    }
+                } else {
+                    error!(
+                        "Processor {} encounter a fatal error `{}`",
+                        $proc_name, proc_err
+                    );
+
+                    // Notify the main task of the error
+                    let _ = $self.remove_proc(Some(proc_err)).await;
+                    return;
+                }
+
+                // Wait a graceful time before restarting the processor
+                sleep(wait_time + recovery_duration).await;
+            } else {
+                // Remove the proc from main
+                let _ = $self.remove_proc(None).await;
+                return;
+            }
+
+            // Don't wait more than the restart delay parameter
+            if wait_time.as_secs() < proc_restart_delay.1 as u64 {
+                wait_time += proc_restart_delay.0;
+                wait_time *= 2;
+            }
+        }
+    };
+}
+
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// Generic trait to define ProSA processor
 ///
@@ -451,6 +513,11 @@ where
     /// Get the number of processor threads the Processors's `Runtime` will use.
     /// Must be implemented by the processor if more than one thread is to be used
     ///
+    /// You can specify values:
+    /// - `0` to spawn your processor on the main runtime
+    /// - `1` to run your processor on a single thread
+    /// - \> `1` to run your processor on a multiple thread Tokio runtime
+    ///
     /// By default, the processor will run on a single thread.
     fn get_proc_threads(&self) -> usize {
         1
@@ -474,83 +541,47 @@ where
     where
         Self: Sized + 'static + std::marker::Send,
     {
-        std::thread::Builder::new()
-            .name(proc_name.clone())
-            .spawn(move || {
-                // build runtime
-                let rt = match self.get_proc_threads() {
-                    1 => runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .thread_name(proc_name.clone())
-                        .build(),
-                    n => runtime::Builder::new_multi_thread()
-                        .worker_threads(n)
-                        .enable_all()
-                        .thread_name(proc_name.clone())
-                        .build(),
-                }
-                .unwrap();
-                rt.block_on(async move {
-                    info!(
-                        "Start processor {} on {} threads",
-                        proc_name,
-                        self.get_proc_threads()
-                    );
-
-                    let proc_restart_delay = self.get_proc_restart_delay();
-                    let mut wait_time = proc_restart_delay.0;
-                    loop {
-                        if let Err(proc_err) = self.internal_run(proc_name.clone()).await {
-                            // Stop the processor immediately if ProSA is shutting down
-                            if self.is_stopping() {
-                                // Remove the proc from main
-                                let _ = self.remove_proc(None).await;
-                                return;
-                            }
-
-                            let recovery_duration = proc_err.recovery_duration();
-
-                            // Log and restart if needed
-                            if proc_err.recoverable() {
-                                warn!(
-                                    "Processor {} encounter an error `{}`. Will restart after {}ms",
-                                    proc_name,
-                                    proc_err,
-                                    (wait_time + recovery_duration).as_millis()
-                                );
-
-                                // Notify the main task of the error
-                                if self.remove_proc(Some(proc_err)).await.is_err() {
-                                    return;
-                                }
-                            } else {
-                                error!(
-                                    "Processor {} encounter a fatal error `{}`",
-                                    proc_name, proc_err
-                                );
-
-                                // Notify the main task of the error
-                                let _ = self.remove_proc(Some(proc_err)).await;
-                                return;
-                            }
-
-                            // Wait a graceful time before restarting the processor
-                            sleep(wait_time + recovery_duration).await;
-                        } else {
-                            // Remove the proc from main
-                            let _ = self.remove_proc(None).await;
-                            return;
-                        }
-
-                        // Don't wait more than the restart delay parameter
-                        if wait_time.as_secs() < proc_restart_delay.1 as u64 {
-                            wait_time += proc_restart_delay.0;
-                            wait_time *= 2;
-                        }
-                    }
+        match self.get_proc_threads() {
+            // Spawn the processor on the current Tokio runtime
+            0 => {
+                spawn(async move {
+                    proc_run!(self, proc_name);
                 });
-            })
-            .unwrap();
+            }
+            // Start a Tokio runtime on a single thread [default]
+            1 => {
+                std::thread::Builder::new()
+                    .name(proc_name.clone())
+                    .spawn(move || {
+                        runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .thread_name(proc_name.clone())
+                            .build()
+                            .unwrap()
+                            .block_on(async {
+                                proc_run!(self, proc_name);
+                            })
+                    })
+                    .unwrap();
+            }
+            // Start a Tokio runtime on multiple threads
+            n => {
+                std::thread::Builder::new()
+                    .name(proc_name.clone())
+                    .spawn(move || {
+                        runtime::Builder::new_multi_thread()
+                            .worker_threads(n)
+                            .enable_all()
+                            .thread_name(proc_name.clone())
+                            .build()
+                            .unwrap()
+                            .block_on(async {
+                                proc_run!(self, proc_name);
+                            })
+                    })
+                    .unwrap();
+            }
+        }
     }
 }
 

--- a/prosa/src/inj/proc.rs
+++ b/prosa/src/inj/proc.rs
@@ -118,16 +118,13 @@ impl Default for InjSettings {
 /// let settings = Settings::default();
 /// let (bus, main) = MainProc::<SimpleStringTvf>::create(&settings);
 ///
-/// // Launch the main task
-/// let main_task = main.run();
-///
 /// // Launch an injector processor
 /// let inj_settings = InjSettings::new("INJ_TEST".into());
 /// let inj_proc = InjProc::<SimpleStringTvf>::create(1, bus.clone(), inj_settings);
 /// Proc::<InjDummyAdaptor>::run(inj_proc, String::from("INJ_PROC"));
 ///
 /// // Wait on main task
-/// //main_task.join().unwrap();
+/// //main.run().await;
 /// ```
 #[proc(settings = prosa::inj::proc::InjSettings)]
 pub struct InjProc {}

--- a/prosa/src/lib.rs
+++ b/prosa/src/lib.rs
@@ -121,7 +121,7 @@ mod tests {
         bus.stop("ProSA unit test end".into()).await.unwrap();
 
         // Wait on main task to end
-        main_task.join().unwrap();
+        main_task.await;
 
         // Check exchanges messages
         let nb_trans = COUNTER.load(Ordering::Relaxed) as u64;

--- a/prosa/src/stub/proc.rs
+++ b/prosa/src/stub/proc.rs
@@ -54,16 +54,13 @@ impl StubSettings {
 /// let settings = Settings::default();
 /// let (bus, main) = MainProc::<SimpleStringTvf>::create(&settings);
 ///
-/// // Launch the main task
-/// let main_task = main.run();
-///
 /// // Launch a stub processor
 /// let stub_settings = StubSettings::new(vec![String::from("STUB_TEST")]);
 /// let stub_proc = StubProc::<SimpleStringTvf>::create(1, bus.clone(), stub_settings);
 /// Proc::<StubParotAdaptor>::run(stub_proc, String::from("STUB_PROC"));
 ///
 /// // Wait on main task
-/// //main_task.join().unwrap();
+/// //main_task.await;
 /// ```
 #[proc(settings = prosa::stub::proc::StubSettings)]
 pub struct StubProc {}

--- a/prosa_macros/src/proc.rs
+++ b/prosa_macros/src/proc.rs
@@ -241,8 +241,12 @@ fn generate_struct_impl_epilogue(
                 #restart_settings_quote
             }
 
-            async fn remove_proc(&self, err: std::option::Option<Box<dyn prosa::core::error::ProcError + Send + Sync>>) -> Result<(), prosa::core::error::BusError> {
+            async fn remove_proc(&self, err: std::option::Option<Box<dyn prosa::core::error::ProcError + std::marker::Send + std::marker::Sync>>) -> std::result::Result<(), prosa::core::error::BusError> {
                 self.proc.remove_proc(err).await
+            }
+
+            fn is_stopping(&self) -> bool {
+                self.proc.is_stopping()
             }
         }
     })


### PR DESCRIPTION
Since PR #21 (with issue #17 ), a bug was introduced because the Tokio runtime wasn't used properly.
This change correct the runtime used in Processors.
For `main()`, the flavor `current_thread` was added to prevent Tokio to launch multiple threads depending of the CPU.

From a system point of view, ProSA now use a correct number of threads.