### PR TITLE
feat: Allow multiple configuration file for cargo-prosa

### DIFF
--- a/cargo-prosa/assets/build.rs.j2
+++ b/cargo-prosa/assets/build.rs.j2
@@ -86,12 +86,12 @@ fn write_config_rs(out_dir: &OsString, desc: &Desc, cargo_metadata: &CargoMetada
     writeln!(f, "{{ '}}' }}\n")?;
 
     writeln!(f, "fn prosa_config(matches: &::clap::ArgMatches) -> Result<::config::Config, ::config::ConfigError> {{ '{{' }}")?;
-    writeln!(f, "    ::config::Config::builder()")?;
-    writeln!(f, "        .add_source(config::File::with_name(")?;
+    writeln!(f, "    prosa::core::settings::get_config_builder(")?;
     writeln!(f, "            matches.get_one::<String>(\"config\").unwrap().as_str(),")?;
-    writeln!(f, "        ))")?;
+    writeln!(f, "        )")?;
+    writeln!(f, "        .map_err(|e| ::config::ConfigError::Foreign(Box::new(e)))?")?;
     writeln!(f, "        .add_source(")?;
-    writeln!(f, "            config::Environment::with_prefix(\"PROSA\")")?;
+    writeln!(f, "            ::config::Environment::with_prefix(\"PROSA\")")?;
     writeln!(f, "                .try_parsing(true)")?;
     writeln!(f, "                .separator(\"_\")")?;
     writeln!(f, "                .list_separator(\" \"),")?;


### PR DESCRIPTION
For the new ProSA Puppet module, we need to handle multiple configuration file.
The configuration is split across multiple configuration file inside a folder.