### PR TITLE
fix: prosa_macros compilation

### DIFF
--- a/prosa_macros/Cargo.toml
+++ b/prosa_macros/Cargo.toml
@@ -13,7 +13,7 @@ include.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = "2"
+syn = { version = "2", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
 chrono.workspace = true

--- a/prosa_macros/src/proc.rs
+++ b/prosa_macros/src/proc.rs
@@ -6,7 +6,6 @@ use syn::{parse::Parser, punctuated::Punctuated};
 
 use crate::add_angle_bracketed;
 
-#[derive(Debug)]
 struct ProcParams {
     settings: Option<syn::Path>,
     queue_size: syn::LitInt,


### PR DESCRIPTION
The `prosa_macros` project don't compile.
This is a fix to make it compile by correcting syn dependency.