### PR TITLE
fix/feat: Use host instead of domain for SSL streams and introduce new Store type

### DIFF
--- a/prosa/src/io.rs
+++ b/prosa/src/io.rs
@@ -270,7 +270,7 @@ mod tests {
 
         let ssl_config = SslConfig::default();
         let ssl_acceptor = ssl_config
-            .init_tls_server_context(addr_url.domain())
+            .init_tls_server_context(addr_url.host_str())
             .unwrap()
             .build();
         let listener = StreamListener::bind(addr)
@@ -332,7 +332,7 @@ mod tests {
 
         let ssl_config = SslConfig::default();
         let ssl_acceptor = ssl_config
-            .init_tls_server_context(addr_url.domain())
+            .init_tls_server_context(addr_url.host_str())
             .unwrap()
             .build();
         let listener = StreamListener::bind(addr)
@@ -447,7 +447,9 @@ mod tests {
 
         let mut client_ssl_config = SslConfig::default();
         client_ssl_config.set_alpn(vec!["http/1.1".into(), "prosa/1".into()]);
-        let ssl_store = Store::new(temp_cert_dir.to_str().unwrap().to_string() + "/");
+        let ssl_store = Store::File {
+            path: temp_cert_dir.to_str().unwrap().to_string(),
+        };
         client_ssl_config.set_store(ssl_store);
         let target_settings = TargetSetting::new(addr, Some(client_ssl_config), None);
         assert_eq!(addr_str, target_settings.to_string());

--- a/prosa/src/io/listener.rs
+++ b/prosa/src/io/listener.rs
@@ -403,7 +403,7 @@ impl ListenerSetting {
             max_socket: Self::default_max_socket(),
         };
 
-        target.init_ssl_context(url.domain());
+        target.init_ssl_context(url.host_str());
         target
     }
 
@@ -433,7 +433,8 @@ impl ListenerSetting {
                 self.ssl.as_ref().map(|c| c.get_ssl_timeout()),
             );
         } else if let Some(ssl_config) = &self.ssl {
-            if let Ok(ssl_acceptor_builder) = ssl_config.init_tls_server_context(self.url.domain())
+            if let Ok(ssl_acceptor_builder) =
+                ssl_config.init_tls_server_context(self.url.host_str())
             {
                 stream_listener = stream_listener.ssl_acceptor(
                     ssl_acceptor_builder.build(),
@@ -442,7 +443,8 @@ impl ListenerSetting {
             }
         } else if url_is_ssl(&self.url) {
             let ssl_config = SslConfig::default();
-            if let Ok(ssl_acceptor_builder) = ssl_config.init_tls_server_context(self.url.domain())
+            if let Ok(ssl_acceptor_builder) =
+                ssl_config.init_tls_server_context(self.url.host_str())
             {
                 stream_listener = stream_listener.ssl_acceptor(
                     ssl_acceptor_builder.build(),

--- a/prosa/src/io/stream.rs
+++ b/prosa/src/io/stream.rs
@@ -194,9 +194,9 @@ impl Stream {
             Self::create_ssl(
                 TcpStream::connect(&*addrs).await?,
                 ssl_context,
-                url.domain().ok_or(io::Error::new(
+                url.host_str().ok_or(io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    format!("Can't retrieve domain name from url `{url}`"),
+                    format!("Can't retrieve host from url `{url}` for ssl"),
                 ))?,
             )
             .await?,

--- a/prosa_utils/src/config/ssl.rs
+++ b/prosa_utils/src/config/ssl.rs
@@ -293,11 +293,11 @@ pub struct SslConfig {
     #[serde(skip_serializing)]
     #[serde(default = "SslConfig::default_modern_security")]
     /// Security level. If `true`, it'll use the [modern version 5 of Mozilla's](https://wiki.mozilla.org/Security/Server_Side_TLS) TLS recommendations.
-    modern_security: bool,
+    pub modern_security: bool,
     #[serde(skip_serializing)]
     #[serde(default = "SslConfig::default_ssl_timeout")]
-    /// SSL operation timeout
-    ssl_timeout: u64,
+    /// SSL operation timeout in milliseconds
+    pub ssl_timeout: u64,
 }
 
 impl SslConfig {

--- a/prosa_utils/src/config/ssl.rs
+++ b/prosa_utils/src/config/ssl.rs
@@ -196,7 +196,7 @@ impl fmt::Display for Store {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let certs = self.get_certs().unwrap_or_default();
         if let Self::File { path } = &self {
-            writeln!(f, "Store cert path [{}]:", path)?;
+            writeln!(f, "Store cert path [{path}]:")?;
         }
         for (name, cert) in certs {
             if f.alternate() {


### PR DESCRIPTION
SSL stream forces the use of domain from Url.
So:
```rust
// This works
let stream: Stream = Stream::connect_ssl(&Url::parse("worldline.com:443").unwrap(), &ssl_context).await?;
// Don't work because url.domain returns None
let stream: Stream = Stream::connect_ssl(&Url::parse("192.168.1.1:443").unwrap(), &ssl_context).await?;
```

In some cases, we need to use IP addresses.
To enable that, we need to change [`domain()`](https://docs.rs/url/latest/url/struct.Url.html#method.domain) into [`host_str()`](https://docs.rs/url/latest/url/struct.Url.html#method.host_str).
IP addresses will be evaluated in that case.

Moreover, the Store currently only loads certificates from files.
This will be extended with this change to add a new type `Store::Cert`, which allows certificate loading with their PEM.
From a configuration point of view, parameters will not change thanks to `serde::untagged`.
So, from a configuration perspective, if a `path` is filled, a File Store will be created, and if it's `certs` with PEM in it, the corresponding `Store::cert` will be created.