### PR TITLE
feat: Add RPM generation

### DIFF
--- a/cargo-prosa/Cargo.toml
+++ b/cargo-prosa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-prosa"
-version = "0.2.0"
+version = "0.2.1"
 authors.workspace = true
 description = "ProSA utility to package and deliver a builded ProSA"
 homepage.workspace = true

--- a/cargo-prosa/README.md
+++ b/cargo-prosa/README.md
@@ -99,3 +99,12 @@ To enable this feature, _create_, _init_ or _update_ your ProSA with the option 
 It'll add every needed properties to generate a deb package.
 
 The deb package will include the released binary, a default configuration file, and a systemd service file.
+
+### RPM package
+
+RPM (Red Hat Package Manager) package can be created with the [cargo-generate-rpm](https://crates.io/crates/cargo-generate-rpm) crate.
+
+To enable this feature, _create_, _init_ or _update_ your ProSA with the option `--rpm`.
+It'll add every needed properties to generate an rpm package.
+
+The rpm package will include the released binary, a default configuration file, and a systemd service file.

--- a/cargo-prosa/assets/build.rs.j2
+++ b/cargo-prosa/assets/build.rs.j2
@@ -9,7 +9,10 @@ use cargo_prosa::cargo::{{ '{' }}CargoMetadata, Metadata{{ '}' }};
 use cargo_prosa::CONFIGURATION_FILENAME;
 {%- if deb_pkg %}
 use cargo_prosa::package::deb::DebPkg;
-{% endif %}
+{% endif -%}
+{%- if rpm_pkg %}
+use cargo_prosa::package::rpm::RpmPkg;
+{% endif -%}
 
 fn write_settings_rs(out_dir: &OsString, desc: &Desc, metadata: &HashMap<&str, Metadata>) -> io::Result<()> {{ '{' }}
     let mut f = fs::File::create(Path::new(&out_dir).join("settings.rs"))?;
@@ -256,7 +259,7 @@ fn main() {{ '{' }}
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=ProSA.toml");
-{%- if deb_pkg %}
+{%- if deb_pkg or rpm_pkg %}
     println!("cargo:rerun-if-changed=Cargo.toml");
 
     // Generate files for ProSA packages
@@ -264,5 +267,9 @@ fn main() {{ '{' }}
 {%- if deb_pkg %}
     let deb_pkg = DebPkg::new(target_path.to_path_buf()).unwrap();
     deb_pkg.write_package_data().unwrap();
+{% endif -%}
+{%- if rpm_pkg %}
+    let rpm_pkg = RpmPkg::new(target_path.to_path_buf()).unwrap();
+    rpm_pkg.write_package_data().unwrap();
 {% endif -%}
 {{ '}' }}

--- a/cargo-prosa/assets/systemd.j2
+++ b/cargo-prosa/assets/systemd.j2
@@ -5,9 +5,9 @@ After=network-online.target
 ConditionFileNotEmpty={{ config }}
 
 [Service]
+Type=simple
 ExecStart={{ bin }} -c {{ config }}
 Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
-Alias={{ name }}.service

--- a/cargo-prosa/src/cargo.rs
+++ b/cargo-prosa/src/cargo.rs
@@ -399,6 +399,7 @@ impl PackageMetadata {
 
         if let Some(metadata) = &self.metadata {
             ctx.insert("deb_pkg", &metadata.contains_key("deb"));
+            ctx.insert("rpm_pkg", &metadata.contains_key("generate-rpm"));
         }
     }
 }

--- a/cargo-prosa/src/package.rs
+++ b/cargo-prosa/src/package.rs
@@ -5,3 +5,6 @@ pub mod container;
 
 /// Module to package ProSA in debian package (`.deb`)
 pub mod deb;
+
+/// Module to package ProSA in Red Hat package (`.rpm`)
+pub mod rpm;

--- a/cargo-prosa/src/package/rpm.rs
+++ b/cargo-prosa/src/package/rpm.rs
@@ -36,14 +36,11 @@ impl RpmPkg {
         let mut binary_assets = toml_edit::InlineTable::new();
         binary_assets.insert(
             "source",
-            toml_edit::Value::String(toml_edit::Formatted::new(format!(
-                "target/release/{}",
-                name
-            ))),
+            toml_edit::Value::String(toml_edit::Formatted::new(format!("target/release/{name}"))),
         );
         binary_assets.insert(
             "dest",
-            toml_edit::Value::String(toml_edit::Formatted::new(format!("/usr/bin/{}", name))),
+            toml_edit::Value::String(toml_edit::Formatted::new(format!("/usr/bin/{name}"))),
         );
         binary_assets.insert(
             "mode",
@@ -85,8 +82,7 @@ impl RpmPkg {
         systemd_assets.insert(
             "dest",
             toml_edit::Value::String(toml_edit::Formatted::new(format!(
-                "/etc/systemd/system/{}.service",
-                name
+                "/etc/systemd/system/{name}.service"
             ))),
         );
         systemd_assets.insert(
@@ -105,8 +101,7 @@ impl RpmPkg {
         readme_assets.insert(
             "dest",
             toml_edit::Value::String(toml_edit::Formatted::new(format!(
-                "/usr/share/doc/{}/README",
-                name
+                "/usr/share/doc/{name}/README"
             ))),
         );
         readme_assets.insert(
@@ -150,7 +145,7 @@ impl RpmPkg {
         // Copy configuration file
         fs::copy(
             self.path.join("config.yml"),
-            pkg_data_path.join(format!("{}.yml", name)),
+            pkg_data_path.join(format!("{name}.yml")),
         )?;
 
         // Write systemd file

--- a/cargo-prosa/src/package/rpm.rs
+++ b/cargo-prosa/src/package/rpm.rs
@@ -1,0 +1,170 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use tera::Tera;
+
+use crate::cargo::CargoMetadata;
+
+/// Struct to handle Container file creation
+pub struct RpmPkg {
+    path: PathBuf,
+    ctx: tera::Context,
+}
+
+impl RpmPkg {
+    const RPM_DATA_TARGET: &'static str = "prosa-rpm";
+
+    /// Create a Red Hat package builder from build.rs script
+    pub fn new(path: PathBuf) -> io::Result<RpmPkg> {
+        let package_metadata = CargoMetadata::load_package_metadata()?;
+        let mut ctx = tera::Context::new();
+        package_metadata.j2_context(&mut ctx);
+
+        // Add package build context
+        ctx.insert(
+            "config",
+            &format!("/etc/ProSA/{}.yml", package_metadata.name),
+        );
+        ctx.insert("bin", &format!("/usr/bin/{}", package_metadata.name));
+
+        Ok(RpmPkg { path, ctx })
+    }
+
+    fn get_binary_assets(name: &str) -> toml_edit::InlineTable {
+        let mut binary_assets = toml_edit::InlineTable::new();
+        binary_assets.insert(
+            "source",
+            toml_edit::Value::String(toml_edit::Formatted::new(format!(
+                "target/release/{}",
+                name
+            ))),
+        );
+        binary_assets.insert(
+            "dest",
+            toml_edit::Value::String(toml_edit::Formatted::new(format!("/usr/bin/{}", name))),
+        );
+        binary_assets.insert(
+            "mode",
+            toml_edit::Value::String(toml_edit::Formatted::new("755".to_string())),
+        );
+        binary_assets
+    }
+
+    fn get_config_assets(name: &str) -> toml_edit::InlineTable {
+        let mut config_assets = toml_edit::InlineTable::new();
+        config_assets.insert(
+            "source",
+            toml_edit::Value::String(toml_edit::Formatted::new(format!(
+                "target/{}/{}.yml",
+                Self::RPM_DATA_TARGET,
+                name
+            ))),
+        );
+        config_assets.insert(
+            "dest",
+            toml_edit::Value::String(toml_edit::Formatted::new("/etc/ProSA/".to_string())),
+        );
+        config_assets.insert(
+            "mode",
+            toml_edit::Value::String(toml_edit::Formatted::new("644".to_string())),
+        );
+        config_assets
+    }
+
+    fn get_systemd_assets(name: &str) -> toml_edit::InlineTable {
+        let mut systemd_assets = toml_edit::InlineTable::new();
+        systemd_assets.insert(
+            "source",
+            toml_edit::Value::String(toml_edit::Formatted::new(format!(
+                "target/{}/service",
+                Self::RPM_DATA_TARGET
+            ))),
+        );
+        systemd_assets.insert(
+            "dest",
+            toml_edit::Value::String(toml_edit::Formatted::new(format!(
+                "/etc/systemd/system/{}.service",
+                name
+            ))),
+        );
+        systemd_assets.insert(
+            "mode",
+            toml_edit::Value::String(toml_edit::Formatted::new("644".to_string())),
+        );
+        systemd_assets
+    }
+
+    fn get_readme_assets(name: &str) -> toml_edit::InlineTable {
+        let mut readme_assets = toml_edit::InlineTable::new();
+        readme_assets.insert(
+            "source",
+            toml_edit::Value::String(toml_edit::Formatted::new("README.md".to_string())),
+        );
+        readme_assets.insert(
+            "dest",
+            toml_edit::Value::String(toml_edit::Formatted::new(format!(
+                "/usr/share/doc/{}/README",
+                name
+            ))),
+        );
+        readme_assets.insert(
+            "mode",
+            toml_edit::Value::String(toml_edit::Formatted::new("644".to_string())),
+        );
+        readme_assets
+    }
+
+    /// Function to add Red Hat package metadata to `Cargo.toml`
+    pub fn add_rpm_pkg_metadata(deb_table: &mut toml_edit::Table, name: &str) {
+        if !deb_table.contains_key("assets") {
+            // Add every assets properties to deb table
+            let mut assets = toml_edit::Array::new();
+
+            assets.push(Self::get_binary_assets(name));
+            assets.push(Self::get_config_assets(name));
+            assets.push(Self::get_systemd_assets(name));
+
+            if Path::new("README.md").is_file() {
+                assets.push(Self::get_readme_assets(name));
+            }
+
+            deb_table.insert("assets", toml_edit::Item::Value(assets.into()));
+        }
+    }
+
+    /// Method to write package data (useful for the deb package) into a folder
+    pub fn write_package_data(&self) -> io::Result<()> {
+        let name = self
+            .ctx
+            .get("name")
+            .and_then(|n| n.as_str())
+            .ok_or(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Missing package name",
+            ))?;
+        let pkg_data_path = self.path.join(Self::RPM_DATA_TARGET);
+        fs::create_dir_all(&pkg_data_path)?;
+
+        // Copy configuration file
+        fs::copy(
+            self.path.join("config.yml"),
+            pkg_data_path.join(format!("{}.yml", name)),
+        )?;
+
+        // Write systemd file
+        let mut tera_build = Tera::default();
+        tera_build
+            .add_raw_template(
+                "prosa.service",
+                include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/systemd.j2")),
+            )
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        let main_file = fs::File::create(pkg_data_path.join("service"))?;
+        tera_build
+            .render_to("prosa.service", &self.ctx, main_file)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+}


### PR DESCRIPTION
This change add the support of RPM generation with [cargo-generate-rpm](https://crates.io/crates/cargo-generate-rpm).
It allow RPM generation for RHEL8/9.

I've tested on a Worldline's RHEL8/9.