### PR TITLE
fix: Correct clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           components: clippy,rustc-dev
       - run: >
-          cargo clippy --color always
-          --verbose --all-targets
+          cargo clippy --color always --verbose
+          --workspace --all-targets
           --all-features --tests
 
   fmt:
@@ -87,5 +87,5 @@ jobs:
           components: llvm-tools, rustc-dev
       - run: >
           cargo test --all-features --release
-          --tests  --verbose --color always
+          --tests --verbose --color always
           --workspace --no-fail-fast

--- a/cargo-prosa/src/cargo.rs
+++ b/cargo-prosa/src/cargo.rs
@@ -81,7 +81,7 @@ impl Metadata {
     /// Method to add the crate name, and description to the metadata
     fn specify(&mut self, crate_name: &str, description: Option<String>) {
         self.description = description;
-        let crate_prefix = format!("{}::", crate_name);
+        let crate_prefix = format!("{crate_name}::");
 
         if let Some(proc) = &mut self.proc {
             proc.insert_str(0, crate_prefix.as_str());
@@ -122,7 +122,7 @@ impl Metadata {
         if let Some(proc) = &self.proc {
             let proc_name = proc.replace('-', "_");
             if let Some(crate_name) = crate_name {
-                let proc_name = format!("{}::{}", crate_name, proc_name);
+                let proc_name = format!("{crate_name}::{proc_name}");
                 if proc_name.contains(name) {
                     return Some(proc);
                 }
@@ -140,7 +140,7 @@ impl Metadata {
             for adaptor in adaptors {
                 let adaptor_name = adaptor.replace('-', "_");
                 if let Some(crate_name) = crate_name {
-                    let adaptor_name = format!("{}::{}", crate_name, adaptor_name);
+                    let adaptor_name = format!("{crate_name}::{adaptor_name}");
                     if adaptor_name.contains(name) {
                         return Some(adaptor);
                     }
@@ -177,7 +177,7 @@ impl Metadata {
         } else {
             None
         }
-        .ok_or(format!("Can't find a ProSA `adaptor` for {}", name))?;
+        .ok_or(format!("Can't find a ProSA `adaptor` for {name}"))?;
 
         Ok(ProcDesc {
             name: None,
@@ -186,7 +186,7 @@ impl Metadata {
                 .proc
                 .clone()
                 .map(|p| p.replace('-', "_"))
-                .ok_or(format!("Missing ProSA `proc` metadata for {}", name))?,
+                .ok_or(format!("Missing ProSA `proc` metadata for {name}"))?,
             adaptor: adaptor.replace('-', "_"),
         })
     }
@@ -195,17 +195,17 @@ impl Metadata {
 impl fmt::Display for Metadata {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(proc) = &self.proc {
-            writeln!(f, "    Processor {}", proc)?;
+            writeln!(f, "    Processor {proc}")?;
         }
 
         if let Some(settings) = &self.settings {
-            writeln!(f, "    Settings {}", settings)?;
+            writeln!(f, "    Settings {settings}")?;
         }
 
         if let Some(adaptor) = &self.adaptor {
             writeln!(f, "    Adaptor:")?;
             for adaptor in adaptor {
-                writeln!(f, "     - {}", adaptor)?;
+                writeln!(f, "     - {adaptor}")?;
             }
         }
 
@@ -421,16 +421,16 @@ impl fmt::Display for PackageMetadata {
             .and_then(|m| m.get("prosa").and_then(|w| w.as_object()))
         {
             for (name, data) in metadata {
-                writeln!(f, "  - {}", name)?;
+                writeln!(f, "  - {name}")?;
                 if name != "main" && name != "tvf" {
                     if let Ok(prosa_metadata) = serde_json::from_value::<Metadata>(data.clone()) {
-                        write!(f, "{}", prosa_metadata)?;
+                        write!(f, "{prosa_metadata}")?;
                     }
                 } else if let Ok(prosa_metadata) =
                     serde_json::from_value::<Vec<String>>(data.clone())
                 {
                     for prosa_meta in prosa_metadata {
-                        writeln!(f, "    - {}", prosa_meta)?;
+                        writeln!(f, "    - {prosa_meta}")?;
                     }
                 }
             }
@@ -586,7 +586,7 @@ impl fmt::Display for CargoMetadata {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for package in &self.packages {
             if package.is_prosa() {
-                write!(f, "{}", package)?;
+                write!(f, "{package}")?;
             }
         }
 

--- a/cargo-prosa/src/main.rs
+++ b/cargo-prosa/src/main.rs
@@ -391,7 +391,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             let mut prosa_toml_file = fs::File::create(CONFIGURATION_FILENAME)?;
                             prosa_toml_file.write_all(prosa_doc.to_string().as_bytes())?;
                         } else {
-                            println!("Will add {}", proc_desc);
+                            println!("Will add {proc_desc}");
                         }
                     }
                 }
@@ -453,7 +453,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 prosa_toml_file.write_all(prosa_doc.to_string().as_bytes())?;
                                 break;
                             } else {
-                                println!("Will replace main proc with {}", main);
+                                println!("Will replace main proc with {main}");
                                 break;
                             }
                         }
@@ -483,7 +483,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 prosa_toml_file.write_all(prosa_doc.to_string().as_bytes())?;
                                 break;
                             } else {
-                                println!("Will replace TVF format with {}", tvf);
+                                println!("Will replace TVF format with {tvf}");
                                 break;
                             }
                         }
@@ -492,14 +492,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             Some(("list", _matches)) => {
                 let cargo_metadata = CargoMetadata::load_metadata()?;
-                print!("{}", cargo_metadata);
+                print!("{cargo_metadata}");
             }
             Some(("container", matches)) => {
                 let container = ContainerFile::new(matches)?;
                 container.create_container_file()?;
 
                 // Help on use
-                print!("{}", container);
+                print!("{container}");
             }
             Some(("completion", matches)) => {
                 let shell = clap_complete::Shell::from_str(

--- a/cargo-prosa/src/package/container.rs
+++ b/cargo-prosa/src/package/container.rs
@@ -97,7 +97,7 @@ impl fmt::Display for ContainerFile {
             if self.path.is_some() {
                 write!(f, " -f {}", self.get_path().display())?;
             }
-            writeln!(f, " -t {} .`", img_name)?;
+            writeln!(f, " -t {img_name} .`")?;
 
             if self.ctx.contains_key("builder_image") {
                 writeln!(
@@ -109,7 +109,7 @@ impl fmt::Display for ContainerFile {
                 if self.path.is_some() {
                     write!(f, " -f {}", self.get_path().display())?;
                 }
-                writeln!(f, " --ssh default=$SSH_AUTH_SOCK -t {} .`", img_name)
+                writeln!(f, " --ssh default=$SSH_AUTH_SOCK -t {img_name} .`")
             } else {
                 Ok(())
             }
@@ -121,7 +121,7 @@ impl fmt::Display for ContainerFile {
                 img_name
             )
         } else {
-            writeln!(f, "  `podman build -t {} .`", img_name)
+            writeln!(f, "  `podman build -t {img_name} .`")
         }
     }
 }

--- a/cargo-prosa/src/package/deb.rs
+++ b/cargo-prosa/src/package/deb.rs
@@ -34,7 +34,7 @@ impl DebPkg {
 
     fn get_binary_assets(name: &str) -> toml_edit::Array {
         let mut binary_assets = toml_edit::Array::new();
-        binary_assets.push(format!("target/release/{}", name));
+        binary_assets.push(format!("target/release/{name}"));
         binary_assets.push("usr/bin/");
         binary_assets.push("755");
         binary_assets
@@ -51,7 +51,7 @@ impl DebPkg {
     fn get_readme_assets(name: &str) -> toml_edit::Array {
         let mut readme_assets = toml_edit::Array::new();
         readme_assets.push("README.md");
-        readme_assets.push(format!("usr/share/doc/{}/README", name));
+        readme_assets.push(format!("usr/share/doc/{name}/README"));
         readme_assets.push("644");
         readme_assets
     }
@@ -128,7 +128,7 @@ impl DebPkg {
         // Copy configuration file
         fs::copy(
             self.path.join("config.yml"),
-            pkg_data_path.join(format!("{}.yml", name)),
+            pkg_data_path.join(format!("{name}.yml")),
         )?;
 
         // Write systemd file

--- a/cargo-prosa/tests/cargo-prosa.rs
+++ b/cargo-prosa/tests/cargo-prosa.rs
@@ -61,8 +61,7 @@ fn project() -> Result<(), Box<dyn std::error::Error>> {
     cmd.assert()
         .success()
         .stderr(predicate::str::contains(format!(
-            "binary (application) `{}` package",
-            PROSA_NAME
+            "binary (application) `{PROSA_NAME}` package"
         )));
     replace_prosa_dependencies(&prosa_path);
 

--- a/prosa/examples/proc.rs
+++ b/prosa/examples/proc.rs
@@ -126,7 +126,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap();
 
     let my_settings = config.try_deserialize::<MySettings>()?;
-    println!("My ProSA settings: {:?}", my_settings);
+    println!("My ProSA settings: {my_settings:?}");
 
     // traces
     let telemetry_filter = TelemetryFilter::new(LevelFilter::DEBUG);

--- a/prosa/src/core/service.rs
+++ b/prosa/src/core/service.rs
@@ -129,7 +129,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (name, services) in self.table.iter() {
-            writeln!(f, "Service name: {}", name)?;
+            writeln!(f, "Service name: {name}")?;
             for service in services {
                 writeln!(f, "\tProcessor ID: {}", service.proc_id)?;
             }
@@ -235,14 +235,14 @@ impl From<TvfError> for ServiceError {
     fn from(err: TvfError) -> Self {
         match err {
             TvfError::FieldNotFound(id) => {
-                ServiceError::ProtocolError(format!("on TVF field {}", id))
+                ServiceError::ProtocolError(format!("on TVF field {id}"))
             }
             TvfError::TypeMismatch => ServiceError::ProtocolError(String::from("on TVF type")),
             TvfError::ConvertionError(str) => {
-                ServiceError::ProtocolError(format!("on TVF convertion {}", str))
+                ServiceError::ProtocolError(format!("on TVF convertion {str}"))
             }
             TvfError::SerializationError(str) => {
-                ServiceError::ProtocolError(format!("on TVF serialization {}", str))
+                ServiceError::ProtocolError(format!("on TVF serialization {str}"))
             }
         }
     }

--- a/prosa/src/core/settings.rs
+++ b/prosa/src/core/settings.rs
@@ -146,7 +146,7 @@ pub fn get_config_builder(path: &str) -> io::Result<ConfigBuilder<DefaultState>>
     } else {
         Err(io::Error::new(
             io::ErrorKind::Unsupported,
-            format!("Unrecognize filetype for path `{}`", path),
+            format!("Unrecognize filetype for path `{path}`"),
         ))
     }
 }

--- a/prosa/src/io.rs
+++ b/prosa/src/io.rs
@@ -117,8 +117,8 @@ impl fmt::Display for SocketAddr {
                     .unwrap_or(Path::new("undefined"))
                     .display()
             ),
-            SocketAddr::V4(ipv4) => write!(f, "{}", ipv4),
-            SocketAddr::V6(ipv6) => write!(f, "{}", ipv6),
+            SocketAddr::V4(ipv4) => write!(f, "{ipv4}"),
+            SocketAddr::V6(ipv6) => write!(f, "{ipv6}"),
         }
     }
 }
@@ -161,15 +161,12 @@ mod tests {
         let listener = StreamListener::Unix(tokio::net::UnixListener::bind(addr).unwrap());
         assert!(listener.as_raw_fd() > 0);
         assert!(
-            format!("{:?}", listener).contains("UnixListener"),
-            "listener `{:?}` don't contain UnixListener",
-            listener
+            format!("{listener:?}").contains("UnixListener"),
+            "listener `{listener:?}` don't contain UnixListener"
         );
         assert!(
-            format!("{:?}", listener).contains(addr),
-            "listener `{:?}` don't contain {}",
-            listener,
-            addr
+            format!("{listener:?}").contains(addr),
+            "listener `{listener:?}` don't contain {addr}"
         );
         assert_eq!(
             "unix:///tmp/prosa_unix_client_server_test.sock",
@@ -191,15 +188,12 @@ mod tests {
             let mut stream = Stream::connect_unix(addr).await.unwrap();
             assert!(stream.as_raw_fd() > 0);
             assert!(
-                format!("{:?}", stream).contains("UnixStream"),
-                "stream `{:?}` don't contain UnixStream",
-                stream
+                format!("{stream:?}").contains("UnixStream"),
+                "stream `{stream:?}` don't contain UnixStream"
             );
             assert!(
-                format!("{:?}", stream).contains(addr),
-                "stream `{:?}` don't contain {}",
-                stream,
-                addr
+                format!("{stream:?}").contains(addr),
+                "stream `{stream:?}` don't contain {addr}"
             );
 
             stream.write_all(b"ProSA").await.unwrap();
@@ -221,14 +215,12 @@ mod tests {
         let listener = StreamListener::bind(addr).await.unwrap();
         assert!(listener.as_raw_fd() > 0);
         assert!(
-            format!("{:?}", listener).contains("Tcp"),
-            "listener `{:?}` don't contain Tcp",
-            listener
+            format!("{listener:?}").contains("Tcp"),
+            "listener `{listener:?}` don't contain Tcp"
         );
         assert!(
-            format!("{:?}", listener).contains("TcpListener"),
-            "listener `{:?}` don't contain TcpListener",
-            listener
+            format!("{listener:?}").contains("TcpListener"),
+            "listener `{listener:?}` don't contain TcpListener"
         );
         assert!(listener.to_string().starts_with("tcp://"));
 
@@ -250,14 +242,12 @@ mod tests {
             let mut stream = Stream::connect_tcp(addr).await.unwrap();
             assert!(stream.as_raw_fd() > 0);
             assert!(
-                format!("{:?}", stream).contains("Tcp"),
-                "stream `{:?}` don't contain Tcp",
-                stream
+                format!("{stream:?}").contains("Tcp"),
+                "stream `{stream:?}` don't contain Tcp"
             );
             assert!(
-                format!("{:?}", stream).contains("TcpStream"),
-                "stream `{:?}` don't contain TcpStream",
-                stream
+                format!("{stream:?}").contains("TcpStream"),
+                "stream `{stream:?}` don't contain TcpStream"
             );
             assert!(stream.to_string().starts_with("tcp://"));
 
@@ -276,7 +266,7 @@ mod tests {
     #[tokio::test]
     async fn ssl_client_server() {
         let addr = "localhost:41443";
-        let addr_url = Url::parse(format!("tls://{}", addr).as_str()).unwrap();
+        let addr_url = Url::parse(format!("tls://{addr}").as_str()).unwrap();
 
         let ssl_config = SslConfig::default();
         let ssl_acceptor = ssl_config
@@ -289,14 +279,12 @@ mod tests {
             .ssl_acceptor(ssl_acceptor, Some(ssl_config.get_ssl_timeout()));
         assert!(listener.as_raw_fd() > 0);
         assert!(
-            format!("{:?}", listener).contains("Ssl"),
-            "listener `{:?}` don't contain Ssl",
-            listener
+            format!("{listener:?}").contains("Ssl"),
+            "listener `{listener:?}` don't contain Ssl"
         );
         assert!(
-            format!("{:?}", listener).contains("TcpListener"),
-            "listener `{:?}` don't contain TcpListener",
-            listener
+            format!("{listener:?}").contains("TcpListener"),
+            "listener `{listener:?}` don't contain TcpListener"
         );
         assert!(listener.to_string().starts_with("ssl://"));
 
@@ -320,9 +308,8 @@ mod tests {
                 .unwrap();
             assert!(stream.as_raw_fd() > 0);
             assert!(
-                format!("{:?}", stream).contains("Ssl"),
-                "stream `{:?}` don't contain Ssl",
-                stream
+                format!("{stream:?}").contains("Ssl"),
+                "stream `{stream:?}` don't contain Ssl"
             );
             assert!(stream.to_string().starts_with("ssl://"));
 
@@ -341,7 +328,7 @@ mod tests {
     #[tokio::test]
     async fn ssl_client_server_raw() {
         let addr = "localhost:41453";
-        let addr_url = Url::parse(format!("tls://{}", addr).as_str()).unwrap();
+        let addr_url = Url::parse(format!("tls://{addr}").as_str()).unwrap();
 
         let ssl_config = SslConfig::default();
         let ssl_acceptor = ssl_config
@@ -354,14 +341,12 @@ mod tests {
             .ssl_acceptor(ssl_acceptor, Some(ssl_config.get_ssl_timeout()));
         assert!(listener.as_raw_fd() > 0);
         assert!(
-            format!("{:?}", listener).contains("Ssl"),
-            "listener `{:?}` don't contain Ssl",
-            listener
+            format!("{listener:?}").contains("Ssl"),
+            "listener `{listener:?}` don't contain Ssl"
         );
         assert!(
-            format!("{:?}", listener).contains("TcpListener"),
-            "listener `{:?}` don't contain TcpListener",
-            listener
+            format!("{listener:?}").contains("TcpListener"),
+            "listener `{listener:?}` don't contain TcpListener"
         );
         assert!(listener.to_string().starts_with("ssl://"));
 
@@ -386,9 +371,8 @@ mod tests {
                 .unwrap();
             assert!(stream.as_raw_fd() > 0);
             assert!(
-                format!("{:?}", stream).contains("Ssl"),
-                "stream `{:?}` don't contain Ssl",
-                stream
+                format!("{stream:?}").contains("Ssl"),
+                "stream `{stream:?}` don't contain Ssl"
             );
             assert!(stream.to_string().starts_with("ssl://"));
 
@@ -415,18 +399,14 @@ mod tests {
 
         let listener_settings = ListenerSetting::new(addr.clone(), Some(server_ssl_config));
         assert!(
-            format!("{:?}", listener_settings).contains("tls")
-                && format!("{:?}", listener_settings).contains("localhost")
-                && format!("{:?}", listener_settings).contains("41463"),
-            "`{:?}` Not contain the address {}",
-            listener_settings,
-            addr_str
+            format!("{listener_settings:?}").contains("tls")
+                && format!("{listener_settings:?}").contains("localhost")
+                && format!("{listener_settings:?}").contains("41463"),
+            "`{listener_settings:?}` Not contain the address {addr_str}"
         );
         assert!(
             listener_settings.to_string().starts_with(addr_str),
-            "`{}` Not start with the address {}",
-            listener_settings,
-            addr_str
+            "`{listener_settings}` Not start with the address {addr_str}"
         );
         assert!(listener_settings.to_string().starts_with(addr_str));
 
@@ -443,14 +423,12 @@ mod tests {
         }
         assert!(listener.as_raw_fd() > 0);
         assert!(
-            format!("{:?}", listener).contains("Ssl"),
-            "listener `{:?}` don't contain Ssl",
-            listener
+            format!("{listener:?}").contains("Ssl"),
+            "listener `{listener:?}` don't contain Ssl"
         );
         assert!(
-            format!("{:?}", listener).contains("TcpListener"),
-            "listener `{:?}` don't contain TcpListener",
-            listener
+            format!("{listener:?}").contains("TcpListener"),
+            "listener `{listener:?}` don't contain TcpListener"
         );
 
         let server = async move {
@@ -478,9 +456,8 @@ mod tests {
             let mut stream = target_settings.connect().await.unwrap();
             assert!(stream.as_raw_fd() > 0);
             assert!(
-                format!("{:?}", stream).contains("Ssl"),
-                "stream `{:?}` don't contain Ssl",
-                stream
+                format!("{stream:?}").contains("Ssl"),
+                "stream `{stream:?}` don't contain Ssl"
             );
             if let Stream::Ssl(s) = &stream {
                 assert_eq!(

--- a/prosa/src/io/listener.rs
+++ b/prosa/src/io/listener.rs
@@ -211,7 +211,7 @@ impl StreamListener {
                     })?
                 {
                     if e.code() != openssl::ssl::ErrorCode::ZERO_RETURN {
-                        return Err(io::Error::other(format!("Can't accept the client: {}", e)));
+                        return Err(io::Error::other(format!("Can't accept the client: {e}")));
                     }
                 }
 
@@ -277,10 +277,7 @@ impl StreamListener {
                         })?
                     {
                         if e.code() != openssl::ssl::ErrorCode::ZERO_RETURN {
-                            return Err(io::Error::other(format!(
-                                "Can't accept the client: {}",
-                                e
-                            )));
+                            return Err(io::Error::other(format!("Can't accept the client: {e}")));
                         }
                     }
 
@@ -326,9 +323,9 @@ impl fmt::Display for StreamListener {
             )));
         match self {
             #[cfg(target_family = "unix")]
-            StreamListener::Unix(_) => write!(f, "unix://{}", addr),
-            StreamListener::Tcp(_) => write!(f, "tcp://{}", addr),
-            StreamListener::Ssl(_, _, _) => write!(f, "ssl://{}", addr),
+            StreamListener::Unix(_) => write!(f, "unix://{addr}"),
+            StreamListener::Tcp(_) => write!(f, "tcp://{addr}"),
+            StreamListener::Ssl(_, _, _) => write!(f, "ssl://{addr}"),
         }
     }
 }
@@ -491,7 +488,7 @@ impl fmt::Display for ListenerSetting {
                 && !url_scheme.ends_with("https")
                 && !url_scheme.ends_with("wss")
             {
-                let _ = url.set_scheme(format!("{}+ssl", url_scheme).as_str());
+                let _ = url.set_scheme(format!("{url_scheme}+ssl").as_str());
             }
         }
 

--- a/prosa/src/io/stream.rs
+++ b/prosa/src/io/stream.rs
@@ -148,7 +148,7 @@ impl Stream {
             if e.code() != ssl::ErrorCode::ZERO_RETURN {
                 return Err(io::Error::new(
                     io::ErrorKind::Interrupted,
-                    format!("Can't connect the SSL socket `{}`", e),
+                    format!("Can't connect the SSL socket `{e}`"),
                 ));
             }
         }
@@ -196,7 +196,7 @@ impl Stream {
                 ssl_context,
                 url.domain().ok_or(io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    format!("Can't retrieve domain name from url `{}`", url),
+                    format!("Can't retrieve domain name from url `{url}`"),
                 ))?,
             )
             .await?,
@@ -224,7 +224,7 @@ impl Stream {
             {
                 return Err(io::Error::new(
                     io::ErrorKind::ConnectionAborted,
-                    format!("Can't connect to the http proxy with basic_auth `{}`", e),
+                    format!("Can't connect to the http proxy with basic_auth `{e}`"),
                 ));
             }
         } else if let Err(e) =
@@ -232,7 +232,7 @@ impl Stream {
         {
             return Err(io::Error::new(
                 io::ErrorKind::ConnectionAborted,
-                format!("Can't connect to the http proxy `{}`", e),
+                format!("Can't connect to the http proxy `{e}`"),
             ));
         }
 
@@ -637,13 +637,13 @@ impl fmt::Display for Stream {
             )));
         match self {
             #[cfg(target_family = "unix")]
-            Stream::Unix(_) => write!(f, "unix://{}", addr),
-            Stream::Tcp(_) => write!(f, "tcp://{}", addr),
-            Stream::Ssl(_) => write!(f, "ssl://{}", addr),
+            Stream::Unix(_) => write!(f, "unix://{addr}"),
+            Stream::Tcp(_) => write!(f, "tcp://{addr}"),
+            Stream::Ssl(_) => write!(f, "ssl://{addr}"),
             #[cfg(feature = "http-proxy")]
-            Stream::TcpHttpProxy(_) => write!(f, "tcp+http_proxy://{}", addr),
+            Stream::TcpHttpProxy(_) => write!(f, "tcp+http_proxy://{addr}"),
             #[cfg(feature = "http-proxy")]
-            Stream::SslHttpProxy(_) => write!(f, "ssl+http_proxy://{}", addr),
+            Stream::SslHttpProxy(_) => write!(f, "ssl+http_proxy://{addr}"),
         }
     }
 }
@@ -829,14 +829,14 @@ impl fmt::Display for TargetSetting {
                 && !url_scheme.ends_with("https")
                 && !url_scheme.ends_with("wss")
             {
-                let _ = url.set_scheme(format!("{}+ssl", url_scheme).as_str());
+                let _ = url.set_scheme(format!("{url_scheme}+ssl").as_str());
             }
         }
 
         if let Some(proxy_url) = &self.proxy {
-            write!(f, "{} -proxy {}", url, proxy_url)
+            write!(f, "{url} -proxy {proxy_url}")
         } else {
-            write!(f, "{}", url)
+            write!(f, "{url}")
         }
     }
 }

--- a/prosa_macros/src/proc.rs
+++ b/prosa_macros/src/proc.rs
@@ -45,7 +45,7 @@ impl ProcParams {
                     } else {
                         return Err(syn::Error::new(
                             name.span(),
-                            format!("unknown proc args value {}", name),
+                            format!("unknown proc args value {name}"),
                         ));
                     }
                 } else {

--- a/prosa_macros/src/settings.rs
+++ b/prosa_macros/src/settings.rs
@@ -60,7 +60,7 @@ where
         } else if let Some(ident) = trait_path.get_ident() {
             Err(syn::Error::new(
                 ident.span(),
-                format!("expected Default impl expression instead of {}", ident),
+                format!("expected Default impl expression instead of {ident}"),
             ))
         } else {
             Err(syn::Error::new(

--- a/prosa_macros/src/tvf/literal.rs
+++ b/prosa_macros/src/tvf/literal.rs
@@ -78,7 +78,7 @@ pub(crate) fn convert_literal(
                         Err(e) => {
                             return Err(Error::new_spanned(
                                 literal,
-                                format!("Cannot convert number to bytes: {}", e),
+                                format!("Cannot convert number to bytes: {e}"),
                             ));
                         }
                     }

--- a/prosa_utils/src/config/observability.rs
+++ b/prosa_utils/src/config/observability.rs
@@ -99,7 +99,7 @@ impl Default for PrometheusExporterCfg {
         };
 
         PrometheusExporterCfg {
-            endpoint: format!("0.0.0.0:{}", port),
+            endpoint: format!("0.0.0.0:{port}"),
         }
     }
 }

--- a/prosa_utils/src/config/ssl.rs
+++ b/prosa_utils/src/config/ssl.rs
@@ -143,9 +143,9 @@ impl fmt::Display for Store {
         writeln!(f, "Store cert path [{}]:", self.path)?;
         for (name, cert) in certs {
             if f.alternate() {
-                writeln!(f, "{}:\n{:#?}", name, cert)?;
+                writeln!(f, "{name}:\n{cert:#?}")?;
             } else {
-                writeln!(f, "{}", name)?;
+                writeln!(f, "{name}")?;
             }
         }
 

--- a/prosa_utils/src/msg/simple_string_tvf.rs
+++ b/prosa_utils/src/msg/simple_string_tvf.rs
@@ -216,7 +216,7 @@ impl SimpleStringTvf {
 
         for (k, v) in self.fields.iter() {
             let len = v.len();
-            out_str.push_str(&format!("{};{};{};", k, len, v));
+            out_str.push_str(&format!("{k};{len};{v};"));
         }
 
         out_str
@@ -344,7 +344,7 @@ mod tests {
     fn test_simple_tvf() {
         let mut simple_tvf: SimpleStringTvf = Default::default();
         test_tvf(&mut simple_tvf);
-        assert!(!format!("{:?}", simple_tvf).is_empty());
+        assert!(!format!("{simple_tvf:?}").is_empty());
         let keys = simple_tvf.keys();
         let into_keys = simple_tvf.clone().into_keys();
         assert_eq!(keys, into_keys);


### PR DESCRIPTION
Clippy threw an error on the master branch because variables can be used directly in the string format tool.
This fix resolves the issue, but all current branches will need to rebase onto the master branch after this change.