### PR TITLE
fix(doc): Fix some errors in the provided doc

### DIFF
--- a/prosa/src/core/proc.rs
+++ b/prosa/src/core/proc.rs
@@ -102,7 +102,7 @@
 //!         self.proc.add_proc().await?;
 //!
 //!         // Retrieve param from the processor settings `MyProcSettings`
-//!         let _param = self.proc.settings.param;
+//!         let _param = &self.settings.param;
 //!
 //!         loop {
 //!             if let Some(msg) = self.internal_rx_queue.recv().await {

--- a/prosa/src/core/settings.rs
+++ b/prosa/src/core/settings.rs
@@ -47,7 +47,7 @@ pub use prosa_macros::settings;
 /// ```
 /// use prosa::core::settings::Settings;
 /// use prosa_utils::config::observability::Observability;
-/// use serde::Serialize;
+/// use serde::{Deserialize, Serialize};
 ///
 /// #[derive(Debug, Deserialize, Serialize)]
 /// struct MySameSettings {


### PR DESCRIPTION
When reviewing your PR, I've noticed some errors in the documentation.
```
oschijns@pop-os /m/o/P/w/ProSA (main)> cargo test
   Compiling prosa v0.2.2 (/media/oschijns/PROJECTS/work/ProSA/prosa)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 6.57s
     Running unittests src/lib.rs (target/debug/deps/cargo_prosa-06ca5caa5ca47faa)

running 1 test
test builder::tests::prosa_desc_toml ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/main.rs (target/debug/deps/cargo_prosa-127ba54ee931e506)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/cargo-prosa.rs (target/debug/deps/cargo_prosa-6bc72542410f71a6)

running 2 tests
test errors ... ok
test project has been running for over 60 seconds
test project ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 98.75s

     Running unittests src/lib.rs (target/debug/deps/prosa-47d52f4fb36e0c94)

running 11 tests
test core::proc::tests::test_proc_settings ... ok
test core::settings::tests::test_settings ... ok
test io::tests::unix_client_server ... ok
test io::tests::tcp_client_server ... ok
test io::tests::ssl_client_server_with_config ... ok
test io::tests::ssl_client_server ... ok
test io::tests::ssl_client_server_raw ... ok
test event::pending::tests::test_pending ... ok
test event::speed::tests::speed_test ... ok
test event::speed::tests::regulator_test ... ok
test tests::prosa ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.00s

     Running unittests src/lib.rs (target/debug/deps/prosa_macros-58535cae9c292735)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/tvf.rs (target/debug/deps/tvf-92109e841dec7dd6)

running 1 test
test macro_tests::test_tvf_macro ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/debug/deps/prosa_utils-87314312dcce9956)

running 6 tests
test config::tests::test_os_country ... ok
test config::tracing::tests::telemetry_level ... ok
test msg::simple_string_tvf::tests::test_tvf_filter ... ok
test msg::simple_string_tvf::tests::test_simple_tvf ... ok
test config::ssl::tests::test_tls_server_context ... ok
test config::ssl::tests::test_store ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

   Doc-tests cargo_prosa

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests prosa

running 31 tests
test prosa/src/core/settings.rs - core::settings::Settings (line 47) ... FAILED
test prosa/src/core.rs - core::proc (line 59) ... FAILED
test prosa/src/core/adaptor.rs - core::adaptor::Adaptor (line 98) ... ok
test prosa/src/event/pending.rs - event::pending::PendingMsgs<T,M>::pull (line 252) ... ok
test prosa/src/event/pending.rs - event::pending::Timers<T>::pull (line 134) ... ok
test prosa/src/core/proc.rs - core::proc::Proc::run (line 513) ... ok
test prosa/src/event/speed.rs - event::speed::Regulator (line 182) ... ok
test prosa/src/event/pending.rs - event::pending::Timers (line 78) ... ok
test prosa/src/core/proc.rs - core::proc::ProcSettings (line 156) ... ok
test prosa/src/event/pending.rs - event::pending::PendingMsgs (line 173) ... ok
test prosa/src/inj/adaptor.rs - inj::adaptor::InjAdaptor (line 8) ... ok
test prosa/src/io/listener.rs - io::listener::ListenerSetting (line 348) ... ok
test prosa/src/io/listener.rs - io::listener::StreamListener::accept (line 170) ... ok
test prosa/src/io/listener.rs - io::listener::StreamListener::accept_raw (line 225) ... ok
test prosa/src/io/listener.rs - io::listener::StreamListener::ssl_acceptor (line 190) ... ok
test prosa/src/io/listener.rs - io::listener::StreamListener::local_addr (line 62) ... ok
test prosa/src/io/listener.rs - io::listener::StreamListener::bind (line 158) ... ok
test prosa/src/io/stream.rs - io::stream::Stream::connect_ssl (line 231) ... ok
test prosa/src/io/stream.rs - io::stream::Stream::connect_ssl_with_http_proxy (line 355) ... ok
test prosa/src/io/stream.rs - io::stream::Stream::selected_alpn_check (line 397) ... ok
test prosa/src/io/stream.rs - io::stream::Stream::connect_tcp (line 177) ... ok
test prosa/src/stub/adaptor.rs - stub::adaptor::StubAdaptor (line 9) ... ok
test prosa/src/io/stream.rs - io::stream::TargetSetting (line 666) ... ok
test prosa/src/io/stream.rs - io::stream::Stream::local_addr (line 44) ... ok
test prosa/src/io/stream.rs - io::stream::Stream::connect_tcp_with_http_proxy (line 317) ... ok
test prosa/src/io/stream.rs - io::stream::Stream::connect_unix (line 146) ... ok
test prosa/src/core/settings.rs - core::settings::Settings (line 22) ... ok
test prosa/src/event/speed.rs - event::speed::Speed (line 9) ... ok
test prosa/src/io.rs - io::url_is_ssl (line 36) ... ok
test prosa/src/inj/proc.rs - inj::proc::InjProc (line 102) ... ok
test prosa/src/stub/proc.rs - stub::proc::StubProc (line 38) ... ok

failures:

---- prosa/src/core/settings.rs - core::settings::Settings (line 47) stdout ----
error: cannot find derive macro `Deserialize` in this scope
  --> prosa/src/core/settings.rs:53:17
   |
9  | #[derive(Debug, Deserialize, Serialize)]
   |                 ^^^^^^^^^^^
   |
  ::: /home/oschijns/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde_derive-1.0.219/src/lib.rs:92:1
   |
92 | pub fn derive_serialize(input: TokenStream) -> TokenStream {
   | ---------------------------------------------------------- similarly named derive macro `Serialize` defined here
   |
help: a derive macro with a similar name exists
   |
9  - #[derive(Debug, Deserialize, Serialize)]
9  + #[derive(Debug, Serialize, Serialize)]
   |
help: consider importing this derive macro
   |
2  + use serde::Deserialize;
   |

error: aborting due to 1 previous error

Couldn't compile the test.
---- prosa/src/core.rs - core::proc (line 59) stdout ----
error[E0609]: no field `settings` on type `ProcParam<M>`
   --> prosa/src/core.rs:156:32
    |
100 |         let _param = self.proc.settings.param;
    |                                ^^^^^^^^ unknown field

error: aborting due to 1 previous error

For more information about this error, try `rustc --explain E0609`.
Couldn't compile the test.

failures:
    prosa/src/core.rs - core::proc (line 59)
    prosa/src/core/settings.rs - core::settings::Settings (line 47)

test result: FAILED. 29 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.59s

error: doctest failed, to rerun pass `-p prosa --doc`
```