### PR TITLE
feat: Update Opentelemetry to 0.29 and remove prometheus_exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 ]
 
 [workspace.dependencies]
-prosa-utils = { version = "0.2.2", path = "prosa_utils" }
+prosa-utils = { version = "0.3.0", path = "prosa_utils" }
 prosa-macros = { version = "0.2.2", path = "prosa_macros" }
 thiserror = "2"
 aquamarine = "0.6"
@@ -37,12 +37,16 @@ toml = "0.8"
 log = "0.4"
 tracing-core = "0.1"
 tracing-subscriber = "0.3"
-tracing-opentelemetry = "0.25"
-opentelemetry = { version = "0.24", features = ["metrics", "trace", "logs"] }
-opentelemetry_sdk = { version = "0.24", features = ["metrics", "trace", "logs", "rt-tokio"] }
-opentelemetry-stdout = { version = "0.5", features = ["metrics", "trace", "logs"]}
-opentelemetry-otlp = { version = "0.17", features = ["metrics", "trace", "logs"]}
-prometheus = { version = "0.13" }
-prometheus_exporter = { version = "0.8", features = ["logging"] }
-opentelemetry-prometheus = { version = "0.17" }
-opentelemetry-appender-log = "0.5"
+tracing-opentelemetry = "0.30"
+opentelemetry = { version = "0.29", features = ["metrics", "trace", "logs"] }
+opentelemetry_sdk = { version = "0.29", features = ["metrics", "trace", "logs", "rt-tokio"] }
+opentelemetry-stdout = { version = "0.29", features = ["metrics", "trace", "logs"]}
+opentelemetry-otlp = { version = "0.29", features = ["metrics", "trace", "logs", "grpc-tonic"]}
+prometheus = { version = "0.14" }
+opentelemetry-prometheus = { version = "0.29" }
+opentelemetry-appender-log = "0.29"
+
+# Web
+hyper = { version = "1", features = ["server", "http1", "http2"] }
+http-body-util = "0.1"
+hyper-util = { version = "0.1", features = ["server-auto", "http1", "http2", "tokio", "tracing"] }

--- a/deny.toml
+++ b/deny.toml
@@ -3,7 +3,6 @@ db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
 ignore = [
-    { id = "RUSTSEC-2024-0437", reason = "this vulnerability does not affect us as prometheus crate don't use the particular code path" },
 ]
 
 [licenses]

--- a/prosa/Cargo.toml
+++ b/prosa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prosa"
-version = "0.2.3"
+version = "0.3.0"
 authors.workspace = true
 description = "ProSA core"
 homepage.workspace = true
@@ -65,6 +65,7 @@ opentelemetry_sdk.workspace = true
 opentelemetry-stdout.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry-appender-log.workspace = true
+prometheus.workspace = true
 memory-stats = "1"
 
 [dev-dependencies]

--- a/prosa/src/core/proc.rs
+++ b/prosa/src/core/proc.rs
@@ -356,13 +356,18 @@ where
         self.main.is_stopping()
     }
 
+    /// Getter of the Prometheus registry
+    pub fn get_prometheus_registry(&self) -> &prometheus::Registry {
+        self.main.get_prometheus_registry()
+    }
+
     /// Provide the opentelemetry Meter based on ProSA settings
-    pub fn meter(&self, name: impl Into<Cow<'static, str>>) -> opentelemetry::metrics::Meter {
+    pub fn meter(&self, name: &'static str) -> opentelemetry::metrics::Meter {
         self.main.meter(name)
     }
 
     /// Provide the opentelemetry Logger based on ProSA settings
-    pub fn logger(&self, name: impl Into<Cow<'static, str>>) -> opentelemetry_sdk::logs::Logger {
+    pub fn logger(&self, name: impl Into<Cow<'static, str>>) -> opentelemetry_sdk::logs::SdkLogger {
         self.main.logger(name)
     }
 

--- a/prosa/src/inj/proc.rs
+++ b/prosa/src/inj/proc.rs
@@ -196,12 +196,12 @@ where
         let mut adaptor = A::new(self)?;
 
         // meter
-        let meter = self.proc.meter(name.clone());
+        let meter = self.proc.meter("prosa_inj");
         let meter_trans_duration = meter
             .f64_histogram("prosa_inj_request_duration")
             .with_description("inj transaction processing duration")
             .with_unit("seconds")
-            .init();
+            .build();
 
         // Declare the processor
         self.proc.add_proc().await?;

--- a/prosa_book/src/ch02-04-observability.md
+++ b/prosa_book/src/ch02-04-observability.md
@@ -28,7 +28,7 @@ where
   let gauge_meter = meter
     .u64_gauge("prosa_gauge_metric_name")
     .with_description("Custom ProSA gauge metric")
-    .init();
+    .build();
 
   // Record your value for the gauge with custom keys
   gauge_meter.record(
@@ -66,7 +66,7 @@ where
 
       // You can call `observe()` multiple time if you have metrics with different labels
     })
-    .init();
+    .build();
 
   value
 }

--- a/prosa_utils/Cargo.toml
+++ b/prosa_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prosa-utils"
-version = "0.2.2"
+version = "0.3.0"
 authors.workspace = true
 description = "ProSA utils"
 homepage.workspace = true
@@ -14,8 +14,8 @@ default = ["full"]
 msg = []
 config = ["dep:glob","dep:serde","dep:serde_yaml"]
 config-openssl = ["config", "dep:openssl"]
-config-observability = ["dep:log", "dep:tracing-core", "dep:tracing-subscriber", "dep:tracing-opentelemetry", "dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-stdout", "dep:opentelemetry-otlp"]
-config-observability-prometheus = ["config-observability", "dep:prometheus", "dep:prometheus_exporter", "dep:opentelemetry-prometheus"]
+config-observability = ["dep:log", "dep:tracing-core", "dep:tracing-subscriber", "dep:tracing-opentelemetry", "dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-stdout", "dep:opentelemetry-otlp", "dep:prometheus"]
+config-observability-prometheus = ["config-observability", "dep:opentelemetry-prometheus", "dep:tokio", "dep:hyper", "dep:http-body-util", "dep:hyper-util"]
 full = ["msg", "config", "config-openssl", "config-observability", "config-observability-prometheus"]
 
 [package.metadata.docs.rs]
@@ -50,8 +50,13 @@ opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-stdout = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 prometheus = { workspace = true, optional = true }
-prometheus_exporter = { workspace = true, optional = true }
 opentelemetry-prometheus = { workspace = true, optional = true }
+
+# Web Observability
+tokio = { workspace = true, optional = true }
+hyper = { workspace = true, optional = true }
+http-body-util = { workspace = true, optional = true }
+hyper-util = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio.workspace = true


### PR DESCRIPTION
This update of Opentelemetry 0.29 remove the `RUSTSEC-2024-0437`.
The replacement of `prometheus_exporter` will allow us to expose Prometheus metrics not only on a dedicated server, but also on an internal API or even on an external HTTP processor.