### PR TITLE
fix: msg_id for internal message and allow custom trace_id

### DIFF
--- a/prosa/examples/proc.rs
+++ b/prosa/examples/proc.rs
@@ -38,7 +38,6 @@ where
             .add_service_proc(vec![String::from("PROC_TEST")])
             .await?;
         let mut interval = time::interval(time::Duration::from_secs(4));
-        let mut msg_id: u64 = 0;
         let mut pending_msgs: PendingMsgs<RequestMsg<M>, M> = Default::default();
         loop {
             tokio::select! {
@@ -80,17 +79,15 @@ where
                     tvf.put_string(2, String::from("request"));
 
                     let stub_service_name = String::from("STUB_TEST");
-                    if let Some(service) = self.service.get_proc_service(&stub_service_name, msg_id) {
+                    if let Some(service) = self.service.get_proc_service(&stub_service_name) {
                         debug!("The service is find: {:?}", service);
-                        service.proc_queue.send(InternalMsg::Request(RequestMsg::new(msg_id, stub_service_name, tvf.clone(), self.proc.get_service_queue()))).await.unwrap();
-                        msg_id += 1;
+                        service.proc_queue.send(InternalMsg::Request(RequestMsg::new(stub_service_name, tvf.clone(), self.proc.get_service_queue()))).await.unwrap();
                     }
 
                     let proc_service_name = String::from("PROC_TEST");
-                    if let Some(service) = self.service.get_proc_service(&proc_service_name, msg_id) {
+                    if let Some(service) = self.service.get_proc_service(&proc_service_name) {
                         debug!("The service is find: {:?}", service);
-                        service.proc_queue.send(InternalMsg::Request(RequestMsg::new(msg_id, proc_service_name, tvf, self.proc.get_service_queue()))).await.unwrap();
-                        msg_id += 1;
+                        service.proc_queue.send(InternalMsg::Request(RequestMsg::new(proc_service_name, tvf, self.proc.get_service_queue()))).await.unwrap();
                     }
                 },
                 Some(msg) = pending_msgs.pull(), if !pending_msgs.is_empty() => {

--- a/prosa/src/core/service.rs
+++ b/prosa/src/core/service.rs
@@ -237,6 +237,22 @@ pub enum ServiceError {
     ProtocolError(String),
 }
 
+impl ServiceError {
+    /// Method to get the error code of the service error
+    /// - 0: No error
+    /// - 1: Unable to reach service
+    /// - 2: Timeout
+    /// - 3: Protocol error
+    pub fn get_code(&self) -> u8 {
+        match self {
+            ServiceError::NoError(_) => 0,
+            ServiceError::UnableToReachService(_) => 1,
+            ServiceError::Timeout(_, _) => 2,
+            ServiceError::ProtocolError(_) => 3,
+        }
+    }
+}
+
 impl From<TvfError> for ServiceError {
     fn from(err: TvfError) -> Self {
         match err {

--- a/prosa/src/event/pending.rs
+++ b/prosa/src/event/pending.rs
@@ -260,7 +260,7 @@ where
     ///     let mut pending_msg: PendingMsgs<RequestMsg<SimpleStringTvf>, SimpleStringTvf> = Default::default();
     ///     let mut msg: Option<RequestMsg<SimpleStringTvf>> = pending_msg.pull().await;
     ///     assert!(msg.is_none());
-    ///     pending_msg.push(RequestMsg::new(1, String::from("service"), tvf, queue), Duration::from_millis(200));
+    ///     pending_msg.push(RequestMsg::new(String::from("service"), tvf, queue), Duration::from_millis(200));
     ///     msg = pending_msg.pull().await;
     ///     assert!(msg.is_some());
     ///     println!("Timeout message {:?}", msg);
@@ -344,8 +344,8 @@ mod tests {
                                 assert_eq!(1, pending_timer.len());
                             },
                             InternalMsg::Service(table) => {
-                                if let Some(service) = table.get_proc_service("TEST", 1) {
-                                    service.proc_queue.send(InternalMsg::Request(RequestMsg::new(1, String::from("TEST"), Default::default(), self.proc.get_service_queue().clone()))).await.unwrap();
+                                if let Some(service) = table.get_proc_service("TEST") {
+                                    service.proc_queue.send(InternalMsg::Request(RequestMsg::new(String::from("TEST"), Default::default(), self.proc.get_service_queue().clone()))).await.unwrap();
                                 }
                             },
                             _ => return Err(BusError::ProcComm(self.get_proc_id(), 0, String::from("Wrong message"))),
@@ -380,10 +380,10 @@ mod tests {
                                 assert_eq!(1, pending_msg.len());
                             },
                             InternalMsg::Service(table) => {
-                                if let Some(service) = table.get_proc_service("TEST", 1) {
+                                if let Some(service) = table.get_proc_service("TEST") {
                                     let mut msg: SimpleStringTvf = Default::default();
                                     msg.put_string(1, "good");
-                                    service.proc_queue.send(InternalMsg::Request(RequestMsg::new(1, String::from("TEST"), msg, self.proc.get_service_queue().clone()))).await.unwrap();
+                                    service.proc_queue.send(InternalMsg::Request(RequestMsg::new(String::from("TEST"), msg, self.proc.get_service_queue().clone()))).await.unwrap();
                                 }
                             },
                             _ => return Err(BusError::ProcComm(self.get_proc_id(), 0, String::from("Wrong message"))),

--- a/prosa/src/lib.rs
+++ b/prosa/src/lib.rs
@@ -93,7 +93,7 @@ mod tests {
             request: M,
         ) -> MaybeAsync<Result<M, ServiceError>> {
             assert!(!request.is_empty());
-            COUNTER.fetch_add(1, Ordering::Relaxed);
+            COUNTER.fetch_add(1, Ordering::SeqCst);
             Ok(request.clone()).into()
         }
     }
@@ -126,7 +126,7 @@ mod tests {
         main_task.await.unwrap();
 
         // Check exchanges messages
-        let nb_trans = COUNTER.load(Ordering::Relaxed) as u64;
+        let nb_trans = COUNTER.load(Ordering::SeqCst) as u64;
         let estimated_trans = WAIT_TIME.as_secs() * 5;
         assert!(nb_trans > (estimated_trans - 2) && nb_trans < (estimated_trans + 2));
         // Should have a coherent number of transaction with the regulator

--- a/prosa_book/src/ch03-05-service.md
+++ b/prosa_book/src/ch03-05-service.md
@@ -165,9 +165,6 @@ After that, you are free to call any services.
         // Register the processor
         self.proc.add_proc().await?;
 
-        // Need to have a unique message id when you send a message
-        let mut msg_id = 0;
-
         // Wait for the service table before sending messages to a service
         loop {
             if let Some(msg) = self.internal_rx_queue.recv().await {
@@ -192,16 +189,13 @@ After that, you are free to call any services.
             }
 
             // Attempt to send a message if the service is available
-            if let Some(service) = self.service.get_proc_service("SERVICE_NAME", msg_id) {
+            if let Some(service) = self.service.get_proc_service("SERVICE_NAME") {
                 let trans = RequestMsg::new(
-                    msg_id,
                     String::from("SERVICE_NAME"),
                     M::default(),
                     self.proc.get_service_queue()
                 );
                 service.proc_queue.send(InternalMsg::Request(trans)).await?;
-
-                msg_id += 1;
             }
         }
 
@@ -227,9 +221,6 @@ The logic is similar to single senders, but you specify the queue when sending m
     async fn internal_run(&mut self, name: String) -> Result<(), Box<dyn ProcError + Send + Sync>> {
         // Register the processor
         self.proc.add_proc().await?;
-
-        // Need to have a unique message id when you send a message
-        let mut msg_id = 0;
 
         // Create a queue for subtask communication
         let (tx_queue, mut rx_queue) = tokio::sync::mpsc::channel(2048);
@@ -265,16 +256,13 @@ The logic is similar to single senders, but you specify the queue when sending m
             }
 
             // Attempt to send a message if the service is available
-            if let Some(service) = self.service.get_proc_service("SERVICE_NAME", msg_id) {
+            if let Some(service) = self.service.get_proc_service("SERVICE_NAME") {
                 let trans = RequestMsg::new(
-                    msg_id,
                     String::from("SERVICE_NAME"),
                     M::default(),
                     tx_msg_queue.clone()
                 );
                 service.proc_queue.send(InternalMsg::Request(trans)).await?;
-
-                msg_id += 1;
             }
         })
 

--- a/prosa_book/src/ch03-06-events.md
+++ b/prosa_book/src/ch03-06-events.md
@@ -33,7 +33,6 @@ There are three important methods you need to use for this object:
             .add_service_proc(vec![String::from("PROC_TEST")])
             .await?;
         let mut interval = time::interval(time::Duration::from_secs(4));
-        let mut msg_id: u64 = 0;
         let mut pending_msgs: PendingMsgs<RequestMsg<M>, M> = Default::default();
         loop {
             tokio::select! {


### PR DESCRIPTION
This merge request addresses a bug that occurs when multiple processors send messages to the same service. If they use the same msg_id, message collisions can occur.

## Fix:

This update uses an atomic operation to generate unique msg_ids across the entire ProSA instance, preventing such collisions.

## Additional Improvement:

When creating a new internal message request, it is now possible to specify a custom trace_id. This enables consistent traceability if the message is forwarded to an external system that supports tracing.
