### PR TITLE
fix: OpenSSL and prepare for more SSL libs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,6 @@ jobs:
         with:
           components: llvm-tools, rustc-dev
       - run: >
-          cargo test --all-features --release
-          --tests --verbose --color always
+          cargo test --release --tests
+          --verbose --color always
           --workspace --no-fail-fast

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 ]
 
 [workspace.dependencies]
-prosa-utils = { version = "0.3.0", path = "prosa_utils" }
+prosa-utils = { version = "0.3.0", path = "prosa_utils", default-features = false }
 prosa-macros = { version = "0.3.0", path = "prosa_macros" }
 thiserror = "2"
 aquamarine = "0.6"
@@ -45,6 +45,9 @@ opentelemetry-otlp = { version = "0.29", features = ["metrics", "trace", "logs",
 prometheus = { version = "0.14" }
 opentelemetry-prometheus = { version = "0.29" }
 opentelemetry-appender-log = "0.29"
+
+# Config SSL
+openssl = { version = "0.10" }
 
 # Web
 hyper = { version = "1", features = ["server", "http1", "http2"] }

--- a/cargo-prosa/Cargo.toml
+++ b/cargo-prosa/Cargo.toml
@@ -15,7 +15,6 @@ path = "src/main.rs"
 
 [dependencies]
 thiserror.workspace = true
-prosa-utils = { workspace = true, features = ["msg", "config", "config-observability"] }
 aquamarine.workspace = true
 clap = "4"
 clap_complete = "4"

--- a/prosa/Cargo.toml
+++ b/prosa/Cargo.toml
@@ -10,8 +10,10 @@ license.workspace = true
 include.workspace = true
 
 [features]
-default = ["http-proxy"]
+default = ["http-proxy", "openssl"]
 http-proxy = ["dep:async-http-proxy"]
+openssl = ["dep:openssl", "dep:tokio-openssl", "prosa-utils/config-openssl"]
+openssl-vendored = ["openssl", "openssl/vendored", "prosa-utils/config-openssl-vendored"]
 
 [[example]]
 name = "proc"
@@ -35,7 +37,7 @@ settings = "stub::proc::StubSettings"
 adaptor = ["stub::adaptor::StubParotAdaptor"]
 
 [dependencies]
-prosa-utils = { workspace = true, features = ["msg", "config", "config-observability"] }
+prosa-utils = { workspace = true, features = ["msg", "config", "config-observability", "config-observability-prometheus"] }
 prosa-macros.workspace = true
 bytes.workspace = true
 tracing = "0.1"
@@ -46,9 +48,9 @@ rlimit = "0.10"
 
 aquamarine.workspace = true
 
-openssl = { version = "0.10" }
+openssl = { workspace = true, optional = true }
 tokio.workspace = true
-tokio-openssl = "0.6"
+tokio-openssl = { version = "0.6", optional = true }
 async-http-proxy = { version = "1", optional = true, features = ["runtime-tokio","basic-auth"] }
 
 serde = { version = "1", features = ["derive"] }

--- a/prosa/src/core/error.rs
+++ b/prosa/src/core/error.rs
@@ -54,6 +54,7 @@ impl ProcError for std::io::Error {
     }
 }
 
+#[cfg(feature = "openssl")]
 impl ProcError for openssl::error::Error {
     fn recoverable(&self) -> bool {
         if let Some(reason) = self.reason() {
@@ -65,6 +66,7 @@ impl ProcError for openssl::error::Error {
     }
 }
 
+#[cfg(feature = "openssl")]
 impl ProcError for openssl::error::ErrorStack {
     fn recoverable(&self) -> bool {
         for error in self.errors() {

--- a/prosa_book/src/ch00-00-prosa.md
+++ b/prosa_book/src/ch00-00-prosa.md
@@ -22,4 +22,4 @@ In fact, ProSA contains no direct references to Worldline's private properties.
 
 ## Version
 
-This book is intended for version 0.2.2 of ProSA.
+This book is intended for version 0.3.0 of ProSA.

--- a/prosa_book/src/ch01-02-02-ssl.md
+++ b/prosa_book/src/ch01-02-02-ssl.md
@@ -2,6 +2,18 @@
 
 Configuring SSL is a complex task, but many options have been provided to make it accessible and flexible.
 
+## Library selection
+
+ProSA through traits:
+- [`SslStore`](https://docs.rs/prosa-utils/latest/prosa_utils/config/ssl/trait.SslStore.html) to handle specific library certificate Store.
+- [`SslConfigContext`](https://docs.rs/prosa-utils/latest/prosa_utils/config/ssl/trait.SslConfigContext.html) to handle specific client/server SSL context for TLS negociation.
+
+allows the use of [OpenSSL](https://docs.rs/prosa-utils/latest/prosa_utils/config/ssl/openssl/index.html) and later more SSL libraries.
+
+By default, ProSA will use OpenSSL, but if you want, you can use the following features to change it:
+- `openssl`: Use OpenSSL by default
+- `openssl-vendored`: [Vendored](https://docs.rs/openssl/latest/openssl/#vendored) OpenSSL that compiles and statically links to the OpenSSL library
+
 ## Store
 
 You have two options to configure an [SSL store](https://docs.rs/prosa-utils/latest/prosa_utils/config/ssl/enum.Store.html):
@@ -83,6 +95,16 @@ ssl_config:
 ```
 
 > If you specify a certificate with a `.der` extention, it will be read as DER-encoded.
+
+### Self signed certificate
+
+If your server connection is SSL (with the `ssl://` or the `+ssl://` suffixed protocol) and you don't specify a certificate and its private key, it'll generate a self-signed certificate.
+
+If you want to retrieve the generated certificate because you need to trust it from a remote, you can specify a certificate path where the certificate will be written:
+```yaml
+ssl_config:
+  cert: "/opt/self_signed_cert.pem"
+```
 
 ### Usage
 

--- a/prosa_macros/Cargo.toml
+++ b/prosa_macros/Cargo.toml
@@ -20,4 +20,4 @@ chrono.workspace = true
 
 [dev-dependencies]
 bytes.workspace = true
-prosa-utils.workspace = true
+prosa-utils = { workspace = true, features = ["msg"] }

--- a/prosa_utils/Cargo.toml
+++ b/prosa_utils/Cargo.toml
@@ -14,6 +14,7 @@ default = ["full"]
 msg = []
 config = ["dep:glob","dep:serde","dep:serde_yaml"]
 config-openssl = ["config", "dep:openssl"]
+config-openssl-vendored = ["config-openssl", "openssl/vendored"]
 config-observability = ["dep:log", "dep:tracing-core", "dep:tracing-subscriber", "dep:tracing-opentelemetry", "dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-stdout", "dep:opentelemetry-otlp", "dep:prometheus"]
 config-observability-prometheus = ["config-observability", "dep:opentelemetry-prometheus", "dep:tokio", "dep:hyper", "dep:http-body-util", "dep:hyper-util"]
 full = ["msg", "config", "config-openssl", "config-observability", "config-observability-prometheus"]
@@ -38,7 +39,7 @@ serde = { version = "1", optional = true, features = ["derive"] }
 serde_yaml = { version = "0.9", optional = true }
 
 # Config OpenSSL
-openssl = { version = "0.10", optional = true }
+openssl = { workspace = true, optional = true }
 
 # Config Observability
 log = { workspace = true, optional = true }

--- a/prosa_utils/src/config.rs
+++ b/prosa_utils/src/config.rs
@@ -4,10 +4,11 @@
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/doc_assets/settings.svg"))]
 //! </svg>
 
+use std::path::PathBuf;
+
 use thiserror::Error;
 
 // Feature openssl or rusttls,...
-#[cfg(feature = "config-openssl")]
 pub mod ssl;
 
 // Feature opentelemetry
@@ -24,9 +25,12 @@ pub enum ConfigError {
     /// Error that indicate a wrong path format in filesystem
     #[error("The config parameter {0} have an incorrect value `{1}`")]
     WrongValue(String, String),
+    /// Error that indicate a wrong path format pattern in filesystem
+    #[error("The path `{0}` provided don't match the pattern `{1}`")]
+    WrongPathPattern(String, glob::PatternError),
     /// Error that indicate a wrong path format in filesystem
-    #[error("The path `{0}` provided is not correct `{1}`")]
-    WrongPath(String, glob::PatternError),
+    #[error("The path `{0}` provided is not correct")]
+    WrongPath(PathBuf),
     /// Error on a file read
     #[error("The file `{0}` can't be read `{1}`")]
     IoFile(String, std::io::Error),

--- a/prosa_utils/src/config/ssl/openssl.rs
+++ b/prosa_utils/src/config/ssl/openssl.rs
@@ -1,0 +1,531 @@
+//! Definition of [OpenSSL](https://www.openssl.org/) configuration
+//!
+//! Implement:
+//! - [`SslStore`](https://docs.rs/prosa-utils/latest/prosa_utils/config/ssl/trait.SslStore.html#impl-SslStore%3CX509,+X509Store%3E-for-Store)
+//! - [`SslConfigContext`](https://docs.rs/prosa-utils/latest/prosa_utils/config/ssl/trait.SslConfigContext.html#impl-SslConfigContext%3CSslConnectorBuilder,+SslAcceptorBuilder%3E-for-SslConfig)
+
+use std::{
+    collections::HashMap,
+    ffi::OsStr,
+    fs::{self, File},
+    io::Write as _,
+    net::IpAddr,
+    ops::DerefMut,
+    time,
+};
+
+use bytes::{BufMut as _, BytesMut};
+use openssl::{
+    asn1::{Asn1Integer, Asn1Time},
+    bn::{BigNum, MsbOption},
+    ec::{Asn1Flag, EcGroup, EcKey},
+    hash::MessageDigest,
+    nid::Nid,
+    pkey::PKey,
+    ssl::{
+        AlpnError, SslAcceptor, SslAcceptorBuilder, SslConnectorBuilder, SslContextBuilder,
+        SslFiletype, SslMethod, SslVerifyMode,
+    },
+    x509::{
+        X509, X509NameBuilder,
+        extension::SubjectAlternativeName,
+        store::{X509Store, X509StoreBuilder},
+    },
+};
+
+use crate::config::{
+    ConfigError, os_country,
+    ssl::{SslConfig, SslConfigContext, SslStore, Store},
+};
+
+impl SslStore<X509, X509Store> for Store {
+    fn get_file_certificates(path: &std::path::Path) -> Result<Vec<X509>, ConfigError> {
+        if path.is_file() {
+            match &path.extension().and_then(OsStr::to_str) {
+                Some("pem" | "crt") => match fs::read(path) {
+                    Ok(pem_file) => Ok(vec![X509::from_pem(&pem_file)?]),
+                    Err(io) => Err(ConfigError::IoFile(
+                        path.to_str().unwrap_or_default().into(),
+                        io,
+                    )),
+                },
+                Some("der" | "cer") => match fs::read(path) {
+                    Ok(der_file) => Ok(vec![X509::from_der(&der_file)?]),
+                    Err(io) => Err(ConfigError::IoFile(
+                        path.to_str().unwrap_or_default().into(),
+                        io,
+                    )),
+                },
+                _ => Ok(Vec::new()),
+            }
+        } else if path.is_symlink() {
+            if let Ok(link) = path.read_link() {
+                <Self as SslStore<X509, X509Store>>::get_file_certificates(&link)
+            } else {
+                Ok(Vec::new())
+            }
+        } else if let Ok(path_dir) = path.read_dir() {
+            let mut cert_list = Vec::new();
+            for dir_entry in path_dir.flatten() {
+                cert_list.append(
+                    &mut <Self as SslStore<X509, X509Store>>::get_file_certificates(
+                        &dir_entry.path(),
+                    )?,
+                );
+            }
+
+            Ok(cert_list)
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    /// Method to get an OpenSSL cert store
+    ///
+    /// ```
+    /// use prosa_utils::config::ssl::{Store, SslStore};
+    ///
+    /// let store = Store::File { path: "./target".into() };
+    /// let openssl_store: openssl::x509::store::X509Store = store.get_store().unwrap();
+    /// ```
+    fn get_store(&self) -> Result<X509Store, ConfigError> {
+        let mut store = X509StoreBuilder::new()?;
+        match self {
+            Store::System => {
+                store.set_default_paths()?;
+                Ok(store.build())
+            }
+            Store::File { path } => match glob::glob(path) {
+                Ok(certs) => {
+                    for cert_path in certs.flatten() {
+                        for cert in
+                            <Self as SslStore<X509, X509Store>>::get_file_certificates(&cert_path)?
+                        {
+                            store.add_cert(cert)?;
+                        }
+                    }
+
+                    Ok(store.build())
+                }
+                Err(e) => Err(ConfigError::WrongPathPattern(path.clone(), e)),
+            },
+            Store::Cert { certs } => {
+                for cert in certs {
+                    store.add_cert(X509::from_pem(cert.as_bytes())?)?;
+                }
+
+                Ok(store.build())
+            }
+        }
+    }
+
+    /// Method to get all OpenSSL certificate with their names as key
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use openssl::x509::X509;
+    /// use prosa_utils::config::ssl::{Store, SslStore};
+    ///
+    /// let store = Store::File { path: "./target".into() };
+    /// let certs_map: HashMap<String, X509> = store.get_certs().unwrap();
+    ///
+    /// // No cert in target
+    /// assert!(certs_map.is_empty());
+    /// ```
+    fn get_certs(&self) -> Result<HashMap<String, X509>, ConfigError> {
+        match self {
+            Store::System => {
+                let store: X509Store = self.get_store()?;
+                let mut certs_map = HashMap::new();
+                for cert in store.all_certificates() {
+                    if let Some(name) = cert
+                        .subject_name()
+                        .entries_by_nid(Nid::COMMONNAME)
+                        .last()
+                        .and_then(|cn| cn.data().as_utf8().map(|cn| cn.to_string()).ok())
+                    {
+                        certs_map.insert(name, cert);
+                    }
+                }
+
+                Ok(certs_map)
+            }
+            Store::File { path } => match glob::glob(path) {
+                Ok(certs) => {
+                    let mut certs_map = HashMap::new();
+                    for cert_path in certs.flatten() {
+                        let certs =
+                            <Self as SslStore<X509, X509Store>>::get_file_certificates(&cert_path)?;
+                        for cert in certs {
+                            if let Some(name) = cert
+                                .subject_name()
+                                .entries_by_nid(Nid::COMMONNAME)
+                                .last()
+                                .and_then(|cn| cn.data().as_utf8().map(|cn| cn.to_string()).ok())
+                            {
+                                certs_map.insert(name, cert);
+                            } else if let Some(cert_name) = cert_path.to_str().and_then(|p| {
+                                p.strip_suffix(".pem").or(p
+                                    .strip_suffix(".crt")
+                                    .or(p.strip_suffix(".der").or(p.strip_suffix(".cer"))))
+                            }) {
+                                certs_map.insert(cert_name.into(), cert);
+                            }
+                        }
+                    }
+
+                    Ok(certs_map)
+                }
+                Err(e) => Err(ConfigError::WrongPathPattern(path.clone(), e)),
+            },
+            Store::Cert { certs } => {
+                let mut certs_map = HashMap::new();
+                for cert_pem in certs {
+                    let cert = X509::from_pem(cert_pem.as_bytes())?;
+                    if let Some(name) = cert
+                        .subject_name()
+                        .entries_by_nid(Nid::COMMONNAME)
+                        .last()
+                        .and_then(|cn| cn.data().as_utf8().map(|cn| cn.to_string()).ok())
+                    {
+                        certs_map.insert(name, cert);
+                    }
+                }
+
+                Ok(certs_map)
+            }
+        }
+    }
+}
+
+/// Method to init an SSL context for a socket
+pub(crate) fn init_openssl_context<B>(
+    config: &SslConfig,
+    mut context_builder: B,
+    is_server: bool,
+    host: Option<&str>,
+) -> Result<B, ConfigError>
+where
+    B: DerefMut<Target = SslContextBuilder>,
+{
+    if let Some(pkcs12_path) = &config.pkcs12 {
+        match fs::read(pkcs12_path) {
+            Ok(pkcs12_file) => {
+                let pkcs12 = ::openssl::pkcs12::Pkcs12::from_der(pkcs12_file.as_ref())?
+                    .parse2(config.passphrase.as_ref().unwrap_or(&String::from("")))?;
+
+                if let Some(pkey) = pkcs12.pkey {
+                    context_builder.set_private_key(&pkey)?;
+                }
+
+                if let Some(cert) = pkcs12.cert {
+                    context_builder.set_certificate(&cert)?;
+                }
+
+                if let Some(ca) = pkcs12.ca {
+                    for cert in ca {
+                        context_builder.add_extra_chain_cert(cert)?;
+                    }
+                }
+            }
+            Err(io) => return Err(ConfigError::IoFile(pkcs12_path.to_string(), io)),
+        }
+    } else if let (Some(cert_path), Some(key_path)) = (&config.cert, &config.key) {
+        context_builder.set_certificate_file(cert_path, SslFiletype::PEM)?;
+
+        match fs::read(key_path) {
+            Ok(key_file) => {
+                let pkey = if key_path.ends_with(".der") || key_path.ends_with(".cer") {
+                    PKey::private_key_from_der(key_file.as_slice())?
+                } else if let Some(passphrase) = &config.passphrase {
+                    PKey::private_key_from_pem_passphrase(
+                        key_file.as_slice(),
+                        passphrase.as_bytes(),
+                    )?
+                } else {
+                    PKey::private_key_from_pem(key_file.as_slice())?
+                };
+
+                context_builder.set_private_key(&pkey)?;
+            }
+            Err(io) => return Err(ConfigError::IoFile(key_path.to_string(), io)),
+        }
+    } else if is_server {
+        let mut group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1)?;
+        group.set_asn1_flag(Asn1Flag::NAMED_CURVE);
+        let pkey = PKey::from_ec_key(EcKey::generate(&group)?)?;
+        context_builder.set_private_key(&pkey)?;
+
+        let mut cert = X509::builder()?;
+        cert.set_version(2)?;
+        cert.set_pubkey(&pkey)?;
+
+        let mut serial_bn = BigNum::new()?;
+        serial_bn.pseudo_rand(64, MsbOption::MAYBE_ZERO, true)?;
+        let serial_number = Asn1Integer::from_bn(&serial_bn)?;
+        cert.set_serial_number(&serial_number)?;
+
+        let begin_valid_time =
+            Asn1Time::from_unix(time::UNIX_EPOCH.elapsed().unwrap().as_secs() as i64 - 360)?;
+        cert.set_not_before(&begin_valid_time)?;
+        let end_valid_time = Asn1Time::days_from_now(1461)?; // 4 years from now
+        cert.set_not_after(&end_valid_time)?;
+
+        let mut x509_name = X509NameBuilder::new()?;
+        if let Some(cn) = os_country() {
+            x509_name.append_entry_by_text("C", cn.as_str())?;
+        }
+        x509_name.append_entry_by_text("CN", "ProSA")?;
+        let x509_name = x509_name.build();
+        cert.set_subject_name(&x509_name)?;
+        cert.set_issuer_name(&x509_name)?;
+
+        // Add DNS or IP subject alternative name if needed to check the certificate
+        if let Some(host) = host {
+            if let Ok(ip) = host.parse::<IpAddr>() {
+                if !ip.is_unspecified() && !ip.is_loopback() {
+                    let mut subject_alternative_name = SubjectAlternativeName::new();
+                    let x509_extension = subject_alternative_name
+                        .ip(host)
+                        .build(&cert.x509v3_context(None, None))?;
+                    cert.append_extension2(&x509_extension)?;
+                }
+            } else {
+                let mut subject_alternative_name = SubjectAlternativeName::new();
+                let x509_extension = subject_alternative_name
+                    .dns(host)
+                    .build(&cert.x509v3_context(None, None))?;
+                cert.append_extension2(&x509_extension)?;
+            }
+        }
+
+        cert.sign(&pkey, MessageDigest::sha256())?;
+        let cert_x509 = cert.build();
+
+        // Write out the certificate if a path for it is specify
+        if let Some(cert_path) = &config.cert {
+            let mut cert_file =
+                File::create(cert_path).map_err(|e| ConfigError::IoFile(cert_path.clone(), e))?;
+            if cert_path.ends_with(".der") || cert_path.ends_with(".cer") {
+                cert_file
+                    .write_all(&cert_x509.to_der()?)
+                    .map_err(|e| ConfigError::IoFile(cert_path.clone(), e))?;
+            } else {
+                cert_file
+                    .write_all(&cert_x509.to_pem()?)
+                    .map_err(|e| ConfigError::IoFile(cert_path.clone(), e))?;
+            }
+        }
+
+        context_builder.set_certificate(&cert_x509)?;
+    }
+
+    if let Some(store) = &config.store {
+        context_builder.set_cert_store(store.get_store()?);
+        if is_server {
+            context_builder.set_verify(SslVerifyMode::PEER);
+        }
+    } else if !is_server {
+        context_builder.set_cert_store(Store::default().get_store()?);
+    } else {
+        context_builder.set_verify(SslVerifyMode::NONE);
+    }
+
+    if !config.alpn.is_empty() {
+        if is_server {
+            let alpn_list = config.alpn.clone();
+            context_builder.set_alpn_select_callback(move |_ssl, alpn| {
+                let mut cli_alpn = HashMap::new();
+
+                let mut current_split = alpn;
+                while let Some(length) = current_split.first() {
+                    if current_split.len() > *length as usize {
+                        let (left, right) = current_split.split_at(*length as usize + 1);
+                        cli_alpn.insert(String::from_utf8(left[1..].to_vec()).unwrap(), &left[1..]);
+                        current_split = right;
+                    } else {
+                        return Err(AlpnError::ALERT_FATAL);
+                    }
+                }
+
+                for alpn_name in &alpn_list {
+                    if let Some(alpn) = cli_alpn.get(alpn_name) {
+                        return Ok(alpn);
+                    }
+                }
+
+                Err(AlpnError::NOACK)
+            });
+        } else {
+            let mut alpn_bytes = BytesMut::new();
+            for alpn in &config.alpn {
+                alpn_bytes.put_u8(alpn.len() as u8);
+                alpn_bytes.put(alpn.as_bytes());
+            }
+
+            context_builder.set_alpn_protos(&alpn_bytes)?;
+        }
+    }
+
+    Ok(context_builder)
+}
+
+impl SslConfigContext<SslConnectorBuilder, SslAcceptorBuilder> for SslConfig {
+    /// Method to init an OpenSSL context for a client socket
+    ///
+    /// ```
+    /// use std::io;
+    /// use std::pin::Pin;
+    /// use tokio::net::TcpStream;
+    /// use tokio_openssl::SslStream;
+    /// use openssl::ssl::{ErrorCode, Ssl, SslMethod, SslVerifyMode};
+    /// use prosa_utils::config::ssl::{SslConfig, SslConfigContext};
+    ///
+    /// async fn client() -> Result<(), io::Error> {
+    ///     let mut stream = TcpStream::connect("localhost:4443").await?;
+    ///
+    ///     let client_config = SslConfig::default();
+    ///     if let Ok(mut ssl_context_builder) = client_config.init_tls_client_context() {
+    ///         let ssl_context = ssl_context_builder.build();
+    ///         let ssl = Ssl::new(&ssl_context.context()).unwrap();
+    ///         let mut stream = SslStream::new(ssl, stream).unwrap();
+    ///         if let Err(e) = Pin::new(&mut stream).connect().await {
+    ///             if e.code() != ErrorCode::ZERO_RETURN {
+    ///                 eprintln!("Can't connect the client: {}", e);
+    ///             }
+    ///         }
+    ///
+    ///         // SSL stream ...
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    fn init_tls_client_context(&self) -> Result<openssl::ssl::SslConnectorBuilder, ConfigError> {
+        let mut ssl_connector = openssl::ssl::SslConnector::builder(SslMethod::tls_client())?;
+        init_openssl_context(self, ssl_connector.deref_mut(), false, None)?;
+        Ok(ssl_connector)
+    }
+
+    /// Method to init an OpenSSL context for a server socket
+    ///
+    /// ```
+    /// use std::io;
+    /// use std::pin::Pin;
+    /// use tokio::net::TcpListener;
+    /// use tokio_openssl::SslStream;
+    /// use openssl::ssl::{ErrorCode, Ssl, SslMethod, SslVerifyMode};
+    /// use prosa_utils::config::ssl::{SslConfig, SslConfigContext};
+    ///
+    /// async fn server() -> Result<(), io::Error> {
+    ///     let listener = TcpListener::bind("0.0.0.0:4443").await?;
+    ///
+    ///     let server_config = SslConfig::new_cert_key("cert.pem".into(), "cert.key".into(), Some("passphrase".into()));
+    ///     if let Ok(mut ssl_context_builder) = server_config.init_tls_server_context(Some("localhost")) {
+    ///         ssl_context_builder.set_verify(SslVerifyMode::NONE);
+    ///         let ssl_context = ssl_context_builder.build();
+    ///
+    ///         loop {
+    ///             let (stream, cli_addr) = listener.accept().await?;
+    ///             let ssl = Ssl::new(&ssl_context.context()).unwrap();
+    ///             let mut stream = SslStream::new(ssl, stream).unwrap();
+    ///             if let Err(e) = Pin::new(&mut stream).accept().await {
+    ///                 if e.code() != ErrorCode::ZERO_RETURN {
+    ///                     eprintln!("Can't accept the client {}: {}", cli_addr, e);
+    ///                 }
+    ///             }
+    ///
+    ///             // SSL stream ...
+    ///         }
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    fn init_tls_server_context(
+        &self,
+        host: Option<&str>,
+    ) -> Result<openssl::ssl::SslAcceptorBuilder, ConfigError> {
+        let mut ssl_acceptor = SslAcceptor::mozilla_modern(SslMethod::tls_server())?;
+        init_openssl_context(self, ssl_acceptor.deref_mut(), true, host)?;
+        Ok(ssl_acceptor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_store() {
+        let store_le_x1_x2 = Store::Cert {
+            certs: vec![
+                "-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW
+T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH
+B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC
+B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv
+KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn
+OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn
+jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw
+qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI
+rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV
+HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq
+hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL
+ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ
+3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK
+NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5
+ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur
+TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC
+jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc
+oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
+4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA
+mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
+emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
+-----END CERTIFICATE-----"
+                    .to_string(),
+                "-----BEGIN CERTIFICATE-----
+MIICGzCCAaGgAwIBAgIQQdKd0XLq7qeAwSxs6S+HUjAKBggqhkjOPQQDAzBPMQsw
+CQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJuZXQgU2VjdXJpdHkgUmVzZWFyY2gg
+R3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBYMjAeFw0yMDA5MDQwMDAwMDBaFw00
+MDA5MTcxNjAwMDBaME8xCzAJBgNVBAYTAlVTMSkwJwYDVQQKEyBJbnRlcm5ldCBT
+ZWN1cml0eSBSZXNlYXJjaCBHcm91cDEVMBMGA1UEAxMMSVNSRyBSb290IFgyMHYw
+EAYHKoZIzj0CAQYFK4EEACIDYgAEzZvVn4CDCuwJSvMWSj5cz3es3mcFDR0HttwW
++1qLFNvicWDEukWVEYmO6gbf9yoWHKS5xcUy4APgHoIYOIvXRdgKam7mAHf7AlF9
+ItgKbppbd9/w+kHsOdx1ymgHDB/qo0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0T
+AQH/BAUwAwEB/zAdBgNVHQ4EFgQUfEKWrt5LSDv6kviejM9ti6lyN5UwCgYIKoZI
+zj0EAwMDaAAwZQIwe3lORlCEwkSHRhtFcP9Ymd70/aTSVaYgLXTWNLxBo1BfASdW
+tL4ndQavEi51mI38AjEAi/V3bNTIZargCyzuFJ0nN6T5U6VR5CmD1/iQMVtCnwr1
+/q4AaOeMSQ+2b1tbFfLn
+-----END CERTIFICATE-----"
+                    .to_string(),
+            ],
+        };
+
+        let certs: HashMap<String, ::openssl::x509::X509> = store_le_x1_x2.get_certs().unwrap();
+        assert!(!certs.is_empty());
+
+        let ossl_store: ::openssl::x509::store::X509Store = store_le_x1_x2.get_store().unwrap();
+        assert!(!ossl_store.all_certificates().is_empty())
+    }
+
+    #[test]
+    fn test_tls_server_context() {
+        let ssl_config = SslConfig::default();
+        let ssl_acceptor_builder: ::openssl::ssl::SslAcceptorBuilder =
+            ssl_config.init_tls_server_context(None).unwrap();
+        let ssl_acceptor = ssl_acceptor_builder.build();
+
+        // Check for self signed certificate
+        assert!(ssl_acceptor.context().private_key().is_some());
+        assert!(ssl_acceptor.context().certificate().is_some());
+    }
+}

--- a/prosa_utils/src/lib.rs
+++ b/prosa_utils/src/lib.rs
@@ -9,6 +9,7 @@
 #![deny(unreachable_pub)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
+#[cfg(feature = "msg")]
 pub mod msg;
 
 #[cfg(feature = "config")]


### PR DESCRIPTION
Changes:
- Accept _.crt_, and _.cer_, along with _.pem_, and _.der_
- Add traits `SslStore` and `SslConfigContext` to prepare for more SSL libs
- Add a System value to Store to load system certificate instead of relying on a default path
- Self certificate can be write as part of configuration (see prosa_book)
- Rename method to match OpenSSL
- Other small fixes
- Improve documentation