### PR TITLE
fix: deny LGPL license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -14,7 +14,7 @@ allow = [
     "ISC",
     "Zlib",
     "Unicode-3.0",
-    "LGPL-3.0",
+    "LGPL-3.0-or-later",
 ]
 confidence-threshold = 0.8
 


### PR DESCRIPTION
A new version of deny now want extended license name.
This will fix pipeline