### PR TITLE
feat/fix: improve config

### DIFF
--- a/prosa/src/core/error.rs
+++ b/prosa/src/core/error.rs
@@ -1,7 +1,10 @@
 use std::time::Duration;
 
 use super::msg::InternalMsg;
-use prosa_utils::msg::tvf::{Tvf, TvfError};
+use prosa_utils::{
+    config::ConfigError,
+    msg::tvf::{Tvf, TvfError},
+};
 use tokio::sync::mpsc;
 
 /// Processor error
@@ -23,6 +26,14 @@ impl<'a, E: ProcError + 'a> From<E> for Box<dyn ProcError + 'a> {
 impl<'a, E: ProcError + Send + Sync + 'a> From<E> for Box<dyn ProcError + Send + Sync + 'a> {
     fn from(err: E) -> Box<dyn ProcError + Send + Sync + 'a> {
         Box::new(err)
+    }
+}
+
+/// For a ProSA `ConfigError`, no recovery is possible.
+/// The configuration need to be valid
+impl ProcError for ConfigError {
+    fn recoverable(&self) -> bool {
+        false
     }
 }
 

--- a/prosa/src/event/speed.rs
+++ b/prosa/src/event/speed.rs
@@ -6,7 +6,7 @@ use tokio::time::{Instant, sleep};
 
 /// Structure to define a transaction flow speed
 ///
-/// ```
+/// ```no_run
 /// use tokio::time::Instant;
 /// use std::time::Duration;
 /// use prosa::event::speed::Speed;


### PR DESCRIPTION
- Implement `ProcError` trait for `ConfigError`. If a processor encounter a config error, it need to stop.
- Use `connect_timeout` in the _connect_ method of `TargetSetting`, otherwise it'll not be used.
- Change `TargetSetting` display to have a cleaner address to be used for metrics for example.