### PR TITLE
fix: docsrs build with new doc_cfg feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 ]
 
 [workspace.dependencies]
-prosa-utils = { version = "0.3.3", path = "prosa_utils", default-features = false }
+prosa-utils = { version = "0.3.4", path = "prosa_utils", default-features = false }
 prosa-macros = { version = "0.3.2", path = "prosa_macros" }
 thiserror = "2"
 aquamarine = "0.6"

--- a/prosa/Cargo.toml
+++ b/prosa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prosa"
-version = "0.3.3"
+version = "0.3.4"
 authors.workspace = true
 description = "ProSA core"
 homepage.workspace = true

--- a/prosa/src/lib.rs
+++ b/prosa/src/lib.rs
@@ -7,7 +7,7 @@
 //! ProSA base library that define standard modules and include procedural macros
 #![warn(missing_docs)]
 #![deny(unreachable_pub)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod core;
 

--- a/prosa_utils/Cargo.toml
+++ b/prosa_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prosa-utils"
-version = "0.3.3"
+version = "0.3.4"
 authors.workspace = true
 description = "ProSA utils"
 homepage.workspace = true

--- a/prosa_utils/src/lib.rs
+++ b/prosa_utils/src/lib.rs
@@ -7,7 +7,7 @@
 //! Utils for ProSA
 #![warn(missing_docs)]
 #![deny(unreachable_pub)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "msg")]
 pub mod msg;


### PR DESCRIPTION
Docsrs have [changed](https://github.com/rust-lang/rust/pull/138907) the parameter `doc_auto_cfg` to `doc_cfg`.
Because of that, ProSA doc [failed](https://docs.rs/crate/prosa/0.3.3/builds/2555507).
To reproduce, you can test it with `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps`