### PR TITLE
fix(book): background worldline image from css

### DIFF
--- a/prosa_book/worldline.css
+++ b/prosa_book/worldline.css
@@ -1,4 +1,4 @@
-#content {
+#content, #mdbook-content {
     background-repeat: no-repeat;
     background-position-x: right;
     background-size: 120px;


### PR DESCRIPTION
The Worldline background image is not displaying because mdbook change its content div id, from `#content` to `#mdbook-content`.