### PR TITLE
feat: add observability labels

### DIFF
--- a/prosa_utils/Cargo.toml
+++ b/prosa_utils/Cargo.toml
@@ -12,7 +12,7 @@ include.workspace = true
 [features]
 default = ["msg", "config", "config-openssl", "config-observability"]
 msg = []
-config = ["dep:glob","dep:serde","dep:serde_yaml", "dep:base64"]
+config = ["dep:glob","dep:serde","dep:serde_yaml", "dep:base64", "dep:uuid"]
 config-openssl = ["config", "dep:openssl"]
 config-openssl-vendored = ["config-openssl", "openssl/vendored"]
 config-observability = ["dep:log", "dep:tracing-core", "dep:tracing-subscriber", "dep:tracing-opentelemetry", "dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-stdout", "dep:opentelemetry-otlp", "dep:opentelemetry-appender-tracing"]
@@ -42,6 +42,7 @@ glob = { version = "0.3", optional = true }
 serde = { workspace = true, optional = true }
 serde_yaml = { version = "0.9", optional = true }
 base64 = { version = "0.22", optional = true }
+uuid = { version = "1", optional = true, features = ["v1", "v4"] }
 
 # Config OpenSSL
 openssl = { workspace = true, optional = true }

--- a/prosa_utils/src/config.rs
+++ b/prosa_utils/src/config.rs
@@ -105,11 +105,28 @@ pub fn hostname() -> Option<String> {
 
 /// Method to get a consistant host ID (UUID v1 or UUID v4) useful for `service.instance.id`
 pub fn hostid() -> String {
-    #[cfg(target_family = "unix")]
+    #[cfg(target_os = "linux")]
     if let Ok(machine_id) = std::fs::read_to_string("/etc/machine-id")
         && let Ok(machine_uuid) = Uuid::parse_str(machine_id.trim())
     {
         return machine_uuid.to_string();
+    }
+
+    #[cfg(target_os = "macos")]
+    if let Ok(output) = Command::new("ioreg")
+        .args(["-rd1", "-c", "IOPlatformExpertDevice"])
+        .output()
+        && output.status.success()
+        && let Ok(output_str) = String::from_utf8(output.stdout)
+    {
+        for line in output_str.lines() {
+            if line.contains("IOPlatformUUID")
+                && let Some(value) = line.split('"').nth(3)
+                && let Ok(machine_uuid) = Uuid::parse_str(value.trim())
+            {
+                return machine_uuid.to_string();
+            }
+        }
     }
 
     if let Some(hostname) = hostname() {

--- a/prosa_utils/src/config.rs
+++ b/prosa_utils/src/config.rs
@@ -9,6 +9,7 @@ use std::{io, path::PathBuf, process::Command};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use thiserror::Error;
 use url::Url;
+use uuid::Uuid;
 
 // Feature openssl or rusttls,...
 pub mod ssl;
@@ -102,6 +103,26 @@ pub fn hostname() -> Option<String> {
     return None;
 }
 
+/// Method to get a consistant host ID (UUID v1 or UUID v4) useful for `service.instance.id`
+pub fn hostid() -> String {
+    #[cfg(target_family = "unix")]
+    if let Ok(machine_id) = std::fs::read_to_string("/etc/machine-id")
+        && let Ok(machine_uuid) = Uuid::parse_str(machine_id.trim())
+    {
+        return machine_uuid.to_string();
+    }
+
+    if let Some(hostname) = hostname() {
+        let mut node_id = [0u8; 6];
+        let len = hostname.len().min(6);
+        node_id[..len].copy_from_slice(&hostname.as_bytes()[hostname.len() - len..]);
+
+        Uuid::now_v1(&node_id).to_string()
+    } else {
+        Uuid::new_v4().to_string()
+    }
+}
+
 /// Method to get authentication value out of URL username/password
 ///
 /// - If user password is provided, it return *Basic* authentication with base64 encoded username:password
@@ -154,6 +175,12 @@ mod tests {
         if let Some(hn) = host {
             assert!(!hn.is_empty());
         }
+    }
+
+    #[test]
+    fn test_hostid() {
+        let host_id = hostid();
+        assert_eq!(host_id.len(), 36);
     }
 
     #[test]

--- a/prosa_utils/src/config/observability.rs
+++ b/prosa_utils/src/config/observability.rs
@@ -458,17 +458,27 @@ impl Observability {
         // start with common attributes
         let mut scope_attr = Self::common_scope_attributes(
             self.get_service_name().to_string(),
-            self.attributes.len() + 2,
+            self.attributes.len() + 4,
         );
 
-        if !self.attributes.contains_key("host.name")
-            && let Some(hostname) = super::hostname()
-        {
+        if let Some(hostname) = self.attributes.get("host.name") {
+            if !self.attributes.contains_key("service.instance.id") {
+                scope_attr.push(KeyValue::new("service.instance.id", hostname.clone()));
+            }
+        } else if let Some(hostname) = super::hostname() {
+            if !self.attributes.contains_key("service.instance.id") {
+                scope_attr.push(KeyValue::new("service.instance.id", hostname.clone()));
+            }
+
             scope_attr.push(KeyValue::new("host.name", hostname));
         }
 
         if !self.attributes.contains_key("service.version") {
             scope_attr.push(KeyValue::new("service.version", env!("CARGO_PKG_VERSION")));
+        }
+
+        if !self.attributes.contains_key("service.namespace") {
+            scope_attr.push(KeyValue::new("service.namespace", "prosa"));
         }
 
         // append custom attributes from configuration

--- a/prosa_utils/src/config/observability.rs
+++ b/prosa_utils/src/config/observability.rs
@@ -458,27 +458,21 @@ impl Observability {
         // start with common attributes
         let mut scope_attr = Self::common_scope_attributes(
             self.get_service_name().to_string(),
-            self.attributes.len() + 4,
+            self.attributes.len() + 3,
         );
 
-        if let Some(hostname) = self.attributes.get("host.name") {
-            if !self.attributes.contains_key("service.instance.id") {
-                scope_attr.push(KeyValue::new("service.instance.id", hostname.clone()));
-            }
-        } else if let Some(hostname) = super::hostname() {
-            if !self.attributes.contains_key("service.instance.id") {
-                scope_attr.push(KeyValue::new("service.instance.id", hostname.clone()));
-            }
-
+        if !self.attributes.contains_key("host.name")
+            && let Some(hostname) = super::hostname()
+        {
             scope_attr.push(KeyValue::new("host.name", hostname));
+        }
+
+        if !self.attributes.contains_key("service.instance.id") {
+            scope_attr.push(KeyValue::new("service.instance.id", super::hostid()));
         }
 
         if !self.attributes.contains_key("service.version") {
             scope_attr.push(KeyValue::new("service.version", env!("CARGO_PKG_VERSION")));
-        }
-
-        if !self.attributes.contains_key("service.namespace") {
-            scope_attr.push(KeyValue::new("service.namespace", "prosa"));
         }
 
         // append custom attributes from configuration


### PR DESCRIPTION
Following tests on Grafana Cloud, metrics are not perfect regarding labels.
From [service semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/service.md) we should have `service.instance.id`, `service.namespace`, `service.name`.
This triplet MUST be globally unique, so this change add these missing labels to have a `job` and `instance` on Grafana Cloud metrics.