### PR TITLE
fix: replace aquamarine with simple mermaid to solve deny error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ license = "LGPL-3.0-or-later"
 
 include = [
     "**/*.rs",
+    "**/*.mmd",
     "Cargo.toml",
     "*assets/*",
     "COPYRIGHT",
@@ -25,7 +26,7 @@ include = [
 prosa-utils = { version = "0.4.3", path = "prosa_utils" }
 prosa-macros = { version = "0.4.2", path = "prosa_macros" }
 thiserror = "2"
-aquamarine = "0.6"
+simple-mermaid = "0.2"
 bytes = "1"
 chrono = "0.4"
 serde = { version = "1", features = ["derive"] }

--- a/cargo-prosa/Cargo.toml
+++ b/cargo-prosa/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/main.rs"
 unwrap_used = "deny"
 
 [dependencies]
-aquamarine.workspace = true
 clap = "4"
 clap_complete = "4"
 serde.workspace = true

--- a/prosa/Cargo.toml
+++ b/prosa/Cargo.toml
@@ -51,7 +51,7 @@ thiserror.workspace = true
 url = { version = "2", features = ["serde"] }
 rlimit = "0.11"
 
-aquamarine.workspace = true
+simple-mermaid.workspace = true
 
 openssl = { workspace = true, optional = true }
 tokio.workspace = true

--- a/prosa/src/core/adaptor.rs
+++ b/prosa/src/core/adaptor.rs
@@ -19,20 +19,10 @@ use std::{fmt, pin::Pin};
 /// Implement the trait [`Adaptor`].
 pub use prosa_macros::Adaptor;
 
-#[cfg_attr(doc, aquamarine::aquamarine)]
 /// Generic ProSA Adaptor.
 /// Define generic function call that are use by every processor.
 ///
-/// ```mermaid
-/// graph LR
-///     task[Task]
-///     adaptor[Adaptor]
-///     bus([Internal service bus])
-///     adaptor <--> bus
-///     subgraph proc[ProSA Processor]
-///     task <--> adaptor
-///     end
-/// ```
+#[doc = simple_mermaid::mermaid!("diagrams/adaptor.mmd")]
 ///
 /// To implement the adaptor without init or terminate function you derive it by default:
 /// ```

--- a/prosa/src/core/diagrams/adaptor.mmd
+++ b/prosa/src/core/diagrams/adaptor.mmd
@@ -1,0 +1,8 @@
+graph LR
+    task[Task]
+    adaptor[Adaptor]
+    bus([Internal service bus])
+    adaptor <--> bus
+    subgraph proc[ProSA Processor]
+    task <--> adaptor
+    end

--- a/prosa/src/core/diagrams/main_bus.mmd
+++ b/prosa/src/core/diagrams/main_bus.mmd
@@ -1,0 +1,20 @@
+graph LR
+    table>Service table]
+    main_queue[(Main queue)]
+    main_task[Main task]
+    proc_queue[(Processor queue)]
+    proc_task[Processor task]
+    proc_io[Processor IOs]
+
+    table <--> main_task
+    table --> proc_task
+    proc_task --> main_queue
+
+    subgraph main[ProSA Main processor]
+    main_queue --> main_task
+    end
+
+    subgraph proc[ProSA Processor]
+    proc_queue --> proc_task
+    proc_task <--> proc_io
+    end

--- a/prosa/src/core/diagrams/msg.mmd
+++ b/prosa/src/core/diagrams/msg.mmd
@@ -1,0 +1,7 @@
+sequenceDiagram
+    Client->>Service: RequestMsg
+    alt is ok
+        Service->>Client: ResponseMsg
+    else is error
+        Service->>Client: ErrorMsg
+    end

--- a/prosa/src/core/diagrams/proc.mmd
+++ b/prosa/src/core/diagrams/proc.mmd
@@ -1,0 +1,12 @@
+graph LR
+    bus([Internal service bus])
+    queue[(Processor queue)]
+    adaptor[Adaptor]
+    task[Task]
+    ext(External system)
+    bus <--> adaptor
+    task <--> ext
+    subgraph proc[ProSA Processor]
+    queue <--> task
+    adaptor <--> task
+    end

--- a/prosa/src/core/main.rs
+++ b/prosa/src/core/main.rs
@@ -41,34 +41,12 @@ where
     fn run(self) -> impl std::future::Future<Output = ()> + Send;
 }
 
-#[cfg_attr(doc, aquamarine::aquamarine)]
 /// Main ProSA task to handle every task spawn in the ProSA
 /// Use an internal ProSA service bus
 /// Must be run only one time in the ProSA
 ///
 /// This is the core strucutre of ProSA.
-/// ```mermaid
-/// graph LR
-///     table>Service table]
-///     main_queue[(Main queue)]
-///     main_task[Main task]
-///     proc_queue[(Processor queue)]
-///     proc_task[Processor task]
-///     proc_io[Processor IOs]
-///
-///     table <--> main_task
-///     table --> proc_task
-///     proc_task --> main_queue
-///
-///     subgraph main[ProSA Main processor]
-///     main_queue --> main_task
-///     end
-///
-///     subgraph proc[ProSA Processor]
-///     proc_queue --> proc_task
-///     proc_task <--> proc_io
-///     end
-/// ```
+#[doc = simple_mermaid::mermaid!("diagrams/main_bus.mmd")]
 #[derive(Clone, Debug)]
 pub struct Main<M>
 where

--- a/prosa/src/core/msg.rs
+++ b/prosa/src/core/msg.rs
@@ -61,18 +61,9 @@ where
     Shutdown,
 }
 
-#[cfg_attr(doc, aquamarine::aquamarine)]
 /// Trait that define a ProSA Msg use to send transactions
 ///
-/// ```mermaid
-/// sequenceDiagram
-///     Client->>Service: RequestMsg
-///     alt is ok
-///         Service->>Client: ResponseMsg
-///     else is error
-///         Service->>Client: ErrorMsg
-///     end
-/// ```
+#[doc = simple_mermaid::mermaid!("diagrams/msg.mmd")]
 pub trait Msg<M>
 where
     M: Sized + Clone + Tvf,

--- a/prosa/src/core/proc.rs
+++ b/prosa/src/core/proc.rs
@@ -537,24 +537,10 @@ macro_rules! proc_run {
     };
 }
 
-#[cfg_attr(doc, aquamarine::aquamarine)]
 /// Generic trait to define ProSA processor
 ///
 /// It regroup several composant:
-/// ```mermaid
-/// graph LR
-///     bus([Internal service bus])
-///     queue[(Processor queue)]
-///     adaptor[Adaptor]
-///     task[Task]
-///     ext(External system)
-///     bus <--> adaptor
-///     task <--> ext
-///     subgraph proc[ProSA Processor]
-///     queue <--> task
-///     adaptor <--> task
-///     end
-/// ```
+#[doc = simple_mermaid::mermaid!("diagrams/proc.mmd")]
 pub trait Proc<A>: ProcBusParam + ProcEpilogue
 where
     A: Adaptor,

--- a/prosa/src/io/diagrams/listener_tcp.mmd
+++ b/prosa/src/io/diagrams/listener_tcp.mmd
@@ -1,0 +1,5 @@
+graph LR
+    clients[Clients]
+    server[Server]
+
+    clients -- TCP --> server

--- a/prosa/src/io/diagrams/listener_tls.mmd
+++ b/prosa/src/io/diagrams/listener_tls.mmd
@@ -1,0 +1,5 @@
+graph LR
+    clients[Clients]
+    server[Server]
+
+    clients -- TLS --> server

--- a/prosa/src/io/diagrams/stream_openssl.mmd
+++ b/prosa/src/io/diagrams/stream_openssl.mmd
@@ -1,0 +1,5 @@
+graph LR
+    client[Client]
+    server[Server]
+
+    client -- TCP+TLS --> server

--- a/prosa/src/io/diagrams/stream_openssl_proxy.mmd
+++ b/prosa/src/io/diagrams/stream_openssl_proxy.mmd
@@ -1,0 +1,7 @@
+graph LR
+    client[Client]
+    server[Server]
+    proxy[Proxy]
+
+    client -- TCP+TLS --> proxy
+    proxy --> server

--- a/prosa/src/io/diagrams/stream_tcp.mmd
+++ b/prosa/src/io/diagrams/stream_tcp.mmd
@@ -1,0 +1,5 @@
+graph LR
+    client[Client]
+    server[Server]
+
+    client -- TCP --> server

--- a/prosa/src/io/diagrams/stream_tcp_proxy.mmd
+++ b/prosa/src/io/diagrams/stream_tcp_proxy.mmd
@@ -1,0 +1,7 @@
+graph LR
+    client[Client]
+    server[Server]
+    proxy[Proxy]
+
+    client -- TCP --> proxy
+    proxy --> server

--- a/prosa/src/io/diagrams/stream_unix.mmd
+++ b/prosa/src/io/diagrams/stream_unix.mmd
@@ -1,0 +1,5 @@
+graph LR
+    client[Client]
+    server[Server]
+
+    client -- UNIX --> server

--- a/prosa/src/io/listener.rs
+++ b/prosa/src/io/listener.rs
@@ -86,16 +86,9 @@ impl StreamListener {
         }
     }
 
-    #[cfg_attr(doc, aquamarine::aquamarine)]
     /// Accept TCP connections from clients
     ///
-    /// ```mermaid
-    /// graph LR
-    ///     clients[Clients]
-    ///     server[Server]
-    ///
-    ///     clients -- TCP --> server
-    /// ```
+    #[doc = simple_mermaid::mermaid!("diagrams/listener_tcp.mmd")]
     ///
     /// ```
     /// use tokio::io;
@@ -118,17 +111,10 @@ impl StreamListener {
     }
 
     #[cfg(feature = "openssl")]
-    #[cfg_attr(doc, aquamarine::aquamarine)]
     /// Set an OpenSSL acceptor to accept SSL connections from clients
     /// By default, the SSL connect timeout is 3 seconds
     ///
-    /// ```mermaid
-    /// graph LR
-    ///     clients[Clients]
-    ///     server[Server]
-    ///
-    ///     clients -- TLS --> server
-    /// ```
+    #[doc = simple_mermaid::mermaid!("diagrams/listener_tls.mmd")]
     ///
     /// ```
     /// use tokio::io;

--- a/prosa/src/io/stream.rs
+++ b/prosa/src/io/stream.rs
@@ -107,16 +107,9 @@ impl Stream {
     }
 
     #[cfg(target_family = "unix")]
-    #[cfg_attr(doc, aquamarine::aquamarine)]
     /// Connect a UNIX socket on a path
     ///
-    /// ```mermaid
-    /// graph LR
-    ///     client[Client]
-    ///     server[Server]
-    ///
-    ///     client -- UNIX --> server
-    /// ```
+    #[doc = simple_mermaid::mermaid!("diagrams/stream_unix.mmd")]
     ///
     /// ```
     /// use tokio::io;
@@ -138,16 +131,9 @@ impl Stream {
         Ok(Stream::Unix(tokio::net::UnixStream::connect(path).await?))
     }
 
-    #[cfg_attr(doc, aquamarine::aquamarine)]
     /// Connect a TCP socket to a distant
     ///
-    /// ```mermaid
-    /// graph LR
-    ///     client[Client]
-    ///     server[Server]
-    ///
-    ///     client -- TCP --> server
-    /// ```
+    #[doc = simple_mermaid::mermaid!("diagrams/stream_tcp.mmd")]
     ///
     /// ```
     /// use tokio::io;
@@ -194,16 +180,9 @@ impl Stream {
     }
 
     #[cfg(feature = "openssl")]
-    #[cfg_attr(doc, aquamarine::aquamarine)]
     /// Connect an OpenSSL socket to a distant
     ///
-    /// ```mermaid
-    /// graph LR
-    ///     client[Client]
-    ///     server[Server]
-    ///
-    ///     client -- TCP+TLS --> server
-    /// ```
+    #[doc = simple_mermaid::mermaid!("diagrams/stream_openssl.mmd")]
     ///
     /// ```
     /// use tokio::io;
@@ -278,18 +257,9 @@ impl Stream {
     }
 
     #[cfg(feature = "http-proxy")]
-    #[cfg_attr(doc, aquamarine::aquamarine)]
     /// Connect a TCP socket to a distant through an HTTP proxy
     ///
-    /// ```mermaid
-    /// graph LR
-    ///     client[Client]
-    ///     server[Server]
-    ///     proxy[Proxy]
-    ///
-    ///     client -- TCP --> proxy
-    ///     proxy --> server
-    /// ```
+    #[doc = simple_mermaid::mermaid!("diagrams/stream_tcp_proxy.mmd")]
     ///
     /// ```
     /// use tokio::io;
@@ -316,18 +286,9 @@ impl Stream {
     }
 
     #[cfg(all(feature = "openssl", feature = "http-proxy"))]
-    #[cfg_attr(doc, aquamarine::aquamarine)]
     /// Connect an OpenSSL socket to a distant through an HTTP proxy
     ///
-    /// ```mermaid
-    /// graph LR
-    ///     client[Client]
-    ///     server[Server]
-    ///     proxy[Proxy]
-    ///
-    ///     client -- TCP+TLS --> proxy
-    ///     proxy --> server
-    /// ```
+    #[doc = simple_mermaid::mermaid!("diagrams/stream_openssl_proxy.mmd")]
     ///
     /// ```
     /// use tokio::io;


### PR DESCRIPTION
We have an issue on the deny check for ProSA, and mermaid didn't updated some dependencies recently.
I propose to switch to simple mermaid to only generate the documentation from mermaid graphs.
It'll simplify the dependencies.