### PR TITLE
ft: re-exported bytes and chrono crates to ease usage of TVF trait

### DIFF
--- a/prosa_utils/src/msg.rs
+++ b/prosa_utils/src/msg.rs
@@ -2,3 +2,7 @@
 
 pub mod simple_string_tvf;
 pub mod tvf;
+
+// re-export types used by TVF trait
+pub use bytes;
+pub use chrono;

--- a/prosa_utils/src/msg.rs
+++ b/prosa_utils/src/msg.rs
@@ -6,3 +6,6 @@ pub mod tvf;
 // re-export types used by TVF trait
 pub use bytes;
 pub use chrono;
+
+pub use bytes::Bytes;
+pub use chrono::{NaiveDate, NaiveDateTime};

--- a/prosa_utils/src/msg.rs
+++ b/prosa_utils/src/msg.rs
@@ -6,6 +6,3 @@ pub mod tvf;
 // re-export types used by TVF trait
 pub use bytes;
 pub use chrono;
-
-pub use bytes::Bytes;
-pub use chrono::{NaiveDate, NaiveDateTime};

--- a/prosa_utils/src/msg/simple_string_tvf.rs
+++ b/prosa_utils/src/msg/simple_string_tvf.rs
@@ -1,9 +1,9 @@
 //! Implementation of a simple String TVF
 
-use bytes::Bytes;
-use chrono::{NaiveDate, NaiveDateTime};
-
-use crate::msg::tvf::{Tvf, TvfError};
+use crate::msg::{
+    Bytes, NaiveDate, NaiveDateTime,
+    tvf::{Tvf, TvfError},
+};
 use std::{borrow::Cow, collections::hash_map::HashMap};
 
 /// Struct that define a simple string TVF

--- a/prosa_utils/src/msg/simple_string_tvf.rs
+++ b/prosa_utils/src/msg/simple_string_tvf.rs
@@ -1,7 +1,8 @@
 //! Implementation of a simple String TVF
 
 use crate::msg::{
-    Bytes, NaiveDate, NaiveDateTime,
+    bytes::Bytes,
+    chrono::{NaiveDate, NaiveDateTime},
     tvf::{Tvf, TvfError},
 };
 use std::{borrow::Cow, collections::hash_map::HashMap};

--- a/prosa_utils/src/msg/tvf.rs
+++ b/prosa_utils/src/msg/tvf.rs
@@ -7,7 +7,10 @@
 //!
 //! [^tvfnote]: **T**ag **V**alue **F**ormat
 
-use crate::msg::{Bytes, NaiveDate, NaiveDateTime};
+use crate::msg::{
+    bytes::Bytes,
+    chrono::{NaiveDate, NaiveDateTime},
+};
 use std::borrow::Cow;
 use std::fmt::Debug;
 use thiserror::Error;

--- a/prosa_utils/src/msg/tvf.rs
+++ b/prosa_utils/src/msg/tvf.rs
@@ -7,8 +7,7 @@
 //!
 //! [^tvfnote]: **T**ag **V**alue **F**ormat
 
-use bytes::Bytes;
-use chrono::{NaiveDate, NaiveDateTime};
+use crate::msg::{Bytes, NaiveDate, NaiveDateTime};
 use std::borrow::Cow;
 use std::fmt::Debug;
 use thiserror::Error;


### PR DESCRIPTION
Using the `Tvf` trait is currently inconvenient as we need to import matching `bytes` and `chrono` crates version.
Re-exporting those two crates makes it trivial to use a matching version.