### PR TITLE
feat: use new cfg_select for cleaner code

### DIFF
--- a/cargo-prosa/src/package/install.rs
+++ b/cargo-prosa/src/package/install.rs
@@ -41,21 +41,27 @@ impl InstanceInstall {
         // Get all path for system or home installation
         let (install_bin_dir, install_config_dir, install_service_dir) = if args.get_flag("system")
         {
-            #[cfg(target_os = "linux")]
-            {
-                (
-                    "/usr/local/bin".to_string(),
-                    "/etc/prosa".to_string(),
-                    "/etc/systemd/system".to_string(),
-                )
-            }
-            #[cfg(target_os = "macos")]
-            {
-                (
-                    "/usr/local/bin".to_string(),
-                    "/etc/prosa".to_string(),
-                    "/Library/LaunchDaemons".to_string(),
-                )
+            cfg_select! {
+                target_os = "linux" => {
+                    (
+                        "/usr/local/bin".to_string(),
+                        "/etc/prosa".to_string(),
+                        "/etc/systemd/system".to_string(),
+                    )
+                }
+                target_os = "macos" => {
+                    (
+                        "/usr/local/bin".to_string(),
+                        "/etc/prosa".to_string(),
+                        "/Library/LaunchDaemons".to_string(),
+                    )
+                }
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        "Install is only supported on Linux and macOS",
+                    ));
+                }
             }
         } else {
             let install_dir = env::var("HOME").map_err(|ve| {
@@ -75,21 +81,27 @@ impl InstanceInstall {
                 ));
             }
 
-            #[cfg(target_os = "linux")]
-            {
-                (
-                    format!("{install_dir}/.local/bin"),
-                    format!("{install_dir}/.config/prosa"),
-                    format!("{install_dir}/.config/systemd/user"),
-                )
-            }
-            #[cfg(target_os = "macos")]
-            {
-                (
-                    format!("{install_dir}/.local/bin"),
-                    format!("{install_dir}/.config/prosa"),
-                    format!("{install_dir}/Library/LaunchAgents"),
-                )
+            cfg_select! {
+                target_os = "linux" => {
+                    (
+                        format!("{install_dir}/.local/bin"),
+                        format!("{install_dir}/.config/prosa"),
+                        format!("{install_dir}/.config/systemd/user"),
+                    )
+                }
+                target_os = "macos" => {
+                    (
+                        format!("{install_dir}/.local/bin"),
+                        format!("{install_dir}/.config/prosa"),
+                        format!("{install_dir}/Library/LaunchAgents"),
+                    )
+                }
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        "Install is only supported on Linux and macOS",
+                    ));
+                }
             }
         };
 

--- a/prosa/src/io/listener.rs
+++ b/prosa/src/io/listener.rs
@@ -383,22 +383,21 @@ pub struct ListenerSetting {
 }
 
 impl ListenerSetting {
-    #[cfg(target_family = "unix")]
     fn default_max_socket() -> u64 {
-        rlimit::Resource::NOFILE
-            .get_soft()
-            .unwrap_or(u32::MAX as u64)
-            - 1
-    }
-
-    #[cfg(target_family = "windows")]
-    fn default_max_socket() -> u64 {
-        (rlimit::getmaxstdio() as u64) - 1
-    }
-
-    #[cfg(all(not(target_family = "unix"), not(target_family = "windows")))]
-    fn default_max_socket() -> u64 {
-        (u32::MAX as u64) - 1
+        cfg_select! {
+            target_family = "unix" => {
+                rlimit::Resource::NOFILE
+                    .get_soft()
+                    .unwrap_or(u32::MAX as u64)
+                    - 1
+            }
+            target_family = "windows" => {
+                (rlimit::getmaxstdio() as u64) - 1
+            }
+            _ => {
+                (u32::MAX as u64) - 1
+            }
+        }
     }
 
     /// Method to create manually a target

--- a/prosa_utils/src/config.rs
+++ b/prosa_utils/src/config.rs
@@ -71,62 +71,66 @@ pub fn os_country() -> Option<String> {
 
 /// Method to try get the hostname from the OS
 pub fn hostname() -> Option<String> {
-    #[cfg(target_family = "unix")]
-    if let Ok(host) = std::env::var("HOSTNAME").map(|h| h.trim().to_string())
-        && !host.is_empty()
-        && !host.contains('\n')
-    {
-        return Some(host);
-    }
+    cfg_select! {
+        target_family = "unix" => {
+            if let Ok(host) = std::env::var("HOSTNAME").map(|h| h.trim().to_string())
+                && !host.is_empty()
+                && !host.contains('\n')
+            {
+                return Some(host);
+            }
 
-    #[cfg(target_family = "unix")]
-    return Command::new("hostname")
-        .arg("-s")
-        .output()
-        .ok()
-        .and_then(|h| {
-            str::from_utf8(h.stdout.trim_ascii())
+            Command::new("hostname")
+                .arg("-s")
+                .output()
                 .ok()
-                .filter(|h| !h.is_empty() && !h.contains('\n'))
-                .map(|h| h.to_string())
-        });
-
-    #[cfg(target_family = "windows")]
-    return Command::new("hostname").output().ok().and_then(|h| {
-        str::from_utf8(h.stdout.trim_ascii())
-            .ok()
-            .filter(|h| !h.is_empty() && !h.contains('\n'))
-            .map(|h| h.to_string())
-    });
-
-    #[cfg(all(not(target_family = "unix"), not(target_family = "windows")))]
-    return None;
+                .and_then(|h| {
+                    str::from_utf8(h.stdout.trim_ascii())
+                        .ok()
+                        .filter(|h| !h.is_empty() && !h.contains('\n'))
+                        .map(|h| h.to_string())
+                })
+        }
+        target_family = "windows" => {
+            Command::new("hostname").output().ok().and_then(|h| {
+                str::from_utf8(h.stdout.trim_ascii())
+                    .ok()
+                    .filter(|h| !h.is_empty() && !h.contains('\n'))
+                    .map(|h| h.to_string())
+            })
+        }
+        _ => None
+    }
 }
 
 /// Method to get a consistant host ID (UUID v1 or UUID v4) useful for `service.instance.id`
 pub fn hostid() -> String {
-    #[cfg(target_os = "linux")]
-    if let Ok(machine_id) = std::fs::read_to_string("/etc/machine-id")
-        && let Ok(machine_uuid) = Uuid::parse_str(machine_id.trim())
-    {
-        return machine_uuid.to_string();
-    }
-
-    #[cfg(target_os = "macos")]
-    if let Ok(output) = Command::new("ioreg")
-        .args(["-rd1", "-c", "IOPlatformExpertDevice"])
-        .output()
-        && output.status.success()
-        && let Ok(output_str) = String::from_utf8(output.stdout)
-    {
-        for line in output_str.lines() {
-            if line.contains("IOPlatformUUID")
-                && let Some(value) = line.split('"').nth(3)
-                && let Ok(machine_uuid) = Uuid::parse_str(value.trim())
+    cfg_select! {
+        target_os = "linux" => {
+            if let Ok(machine_id) = std::fs::read_to_string("/etc/machine-id")
+                && let Ok(machine_uuid) = Uuid::parse_str(machine_id.trim())
             {
                 return machine_uuid.to_string();
             }
         }
+        target_os = "macos" => {
+            if let Ok(output) = Command::new("ioreg")
+                .args(["-rd1", "-c", "IOPlatformExpertDevice"])
+                .output()
+                && output.status.success()
+                && let Ok(output_str) = String::from_utf8(output.stdout)
+            {
+                for line in output_str.lines() {
+                    if line.contains("IOPlatformUUID")
+                        && let Some(value) = line.split('"').nth(3)
+                        && let Ok(machine_uuid) = Uuid::parse_str(value.trim())
+                    {
+                        return machine_uuid.to_string();
+                    }
+                }
+            }
+        }
+        _ => {}
     }
 
     if let Some(hostname) = hostname() {


### PR DESCRIPTION
In the Rust version [1.95.0](https://blog.rust-lang.org/2026/04/16/Rust-1.95.0/), there is the new [cfg_select!](https://doc.rust-lang.org/stable/std/macro.cfg_select.html) macro that allow to simplify the write of cfg predicates.
This MR use this new macro to replace inclusion to make the code cleaner.