### PR TITLE
fix: update residual and fix performance and issues

### DIFF
--- a/prosa/src/inj/proc.rs
+++ b/prosa/src/inj/proc.rs
@@ -152,7 +152,7 @@ impl InjProc {
                     &[
                         KeyValue::new("proc", self.name().to_string()),
                         KeyValue::new("service", msg.get_service().clone()),
-                        KeyValue::new("err_code", "0".to_string()),
+                        KeyValue::new("err_code", 0),
                     ],
                 );
 
@@ -163,7 +163,7 @@ impl InjProc {
                     regulator.notify_receive_transaction(msg.elapsed());
 
                     // Build the next transaction
-                    let _ = next_transaction.get_or_insert(adaptor.build_transaction());
+                    let _ = next_transaction.get_or_insert_with(|| adaptor.build_transaction());
                 }
             }
             InternalMsg::Error(err_msg) => {
@@ -173,7 +173,7 @@ impl InjProc {
                     &[
                         KeyValue::new("proc", self.name().to_string()),
                         KeyValue::new("service", err_msg.get_service().clone()),
-                        KeyValue::new("err_code", err_msg.get_err().get_code().to_string()),
+                        KeyValue::new("err_code", err_msg.get_err().get_code() as i64),
                     ],
                 );
 
@@ -195,7 +195,7 @@ impl InjProc {
                 regulator.notify_receive_transaction(err_msg.elapsed());
 
                 // Build the next transaction
-                let _ = next_transaction.get_or_insert(adaptor.build_transaction());
+                let _ = next_transaction.get_or_insert_with(|| adaptor.build_transaction());
             }
             InternalMsg::Config(config) => {
                 let settings = match config.get_proc::<InjSettings>(self.proc.as_ref()) {

--- a/prosa/src/io.rs
+++ b/prosa/src/io.rs
@@ -6,10 +6,14 @@ use std::{
     path::Path,
 };
 
-use url::Url;
+use tokio::net::lookup_host;
+use url::{Host, Url};
 
 pub use prosa_macros::io;
-pub use prosa_utils::config::ssl::{SslConfig, SslConfigContext};
+pub use prosa_utils::config::{
+    ssl::{SslConfig, SslConfigContext},
+    url::{SafeUrl, get_safe_url},
+};
 
 pub mod listener;
 pub mod stream;
@@ -49,6 +53,52 @@ pub fn url_is_ssl(url: &Url) -> bool {
         true
     } else {
         matches!(url.scheme(), "ssl" | "tls" | "https" | "wss")
+    }
+}
+
+/// Resolve a URL host asynchronously.
+///
+/// Domain names are resolved through Tokio. Literal IPv4 and IPv6 addresses are returned directly
+/// without a DNS lookup. The explicit URL port is used when present; otherwise the scheme's known
+/// default port is used.
+///
+/// # Errors
+///
+/// Returns an error when the URL has no host, has neither an explicit nor a known default port, or
+/// when domain-name resolution fails.
+///
+/// ```
+/// use prosa::io::lookup_url;
+/// use url::Url;
+///
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let url = Url::parse("http://localhost:8080")?;
+/// let addresses = lookup_url(&url).await?;
+///
+/// assert!(!addresses.is_empty());
+/// assert!(addresses.iter().all(|address| address.port() == 8080));
+/// # Ok(())
+/// # }
+/// ```
+pub async fn lookup_url(url: &Url) -> Result<Vec<std::net::SocketAddr>, std::io::Error> {
+    let host = url.host().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("No host name in the URL ({})", get_safe_url(url)),
+        )
+    })?;
+    let port = url.port_or_known_default().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("No port number in the URL ({})", get_safe_url(url)),
+        )
+    })?;
+
+    match host {
+        Host::Domain(domain) => Ok(lookup_host((domain, port)).await?.collect()),
+        Host::Ipv4(ip) => Ok(vec![(ip, port).into()]),
+        Host::Ipv6(ip) => Ok(vec![(ip, port).into()]),
     }
 }
 

--- a/prosa/src/io/listener.rs
+++ b/prosa/src/io/listener.rs
@@ -16,7 +16,7 @@ pub use prosa_macros::io;
 use tokio::net::{TcpListener, ToSocketAddrs, UnixListener};
 use url::Url;
 
-use super::{SocketAddr, stream::Stream, url_is_ssl};
+use super::{SafeUrl, SocketAddr, get_safe_url, stream::Stream, url_is_ssl};
 
 /// ProSA socket object to handle TCP/SSL server socket
 pub enum StreamListener {
@@ -208,7 +208,6 @@ impl StreamListener {
                                 ),
                             )
                         })?
-                    && e.code() != openssl::ssl::ErrorCode::ZERO_RETURN
                 {
                     return Err(io::Error::other(format!("Can't accept the client: {e}")));
                 }
@@ -280,7 +279,6 @@ impl StreamListener {
                                     ),
                                 )
                             })?
-                        && e.code() != openssl::ssl::ErrorCode::ZERO_RETURN
                     {
                         return Err(io::Error::other(format!("Can't accept the client: {e}")));
                     }
@@ -417,6 +415,15 @@ impl ListenerSetting {
         target
     }
 
+    /// Return a borrowed safe view of the listener URL.
+    ///
+    /// Formatting the [`SafeUrl`] masks credentials and omits the query and fragment without
+    /// cloning. Callers can use [`SafeUrl::to_url`] to obtain an owned URL without credentials, or
+    /// [`SafeUrl::to_mask_url`] to obtain one with masked credentials.
+    pub fn get_safe_url(&self) -> SafeUrl<'_> {
+        get_safe_url(&self.url)
+    }
+
     #[cfg(feature = "openssl")]
     /// Method to init the ssl context out of the ssl target configuration.
     /// Must be call when the configuration is retrieved
@@ -511,7 +518,7 @@ impl From<Url> for ListenerSetting {
 impl fmt::Debug for ListenerSetting {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ListenerSetting")
-            .field("url", &self.url)
+            .field("url", &self.get_safe_url())
             .field("ssl", &self.ssl)
             .field("max_socket", &self.max_socket)
             .finish()
@@ -520,7 +527,7 @@ impl fmt::Debug for ListenerSetting {
 
 impl fmt::Display for ListenerSetting {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut url = self.url.clone();
+        let mut url = self.get_safe_url().to_mask_url();
         if self.ssl.is_some() {
             let url_scheme = url.scheme();
             if url_scheme.is_empty() {
@@ -535,5 +542,32 @@ impl fmt::Display for ListenerSetting {
         }
 
         write!(f, "{} -max_socket {}", url, self.max_socket)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn listener_setting_display_redacts_url_secrets() {
+        let mut setting = ListenerSetting::from(
+            Url::parse("tcp://admin:secret@localhost:8080/v1?token=secret#access_token=secret")
+                .expect("Listener URL should be valid"),
+        );
+        setting.max_socket = 42;
+
+        assert_eq!(
+            "tcp://***:***@localhost:8080/v1",
+            setting.get_safe_url().to_string()
+        );
+        assert_eq!(
+            "tcp://localhost:8080/v1",
+            setting.get_safe_url().to_url().as_str()
+        );
+        assert_eq!(
+            "tcp://***:***@localhost:8080/v1 -max_socket 42",
+            setting.to_string()
+        );
     }
 }

--- a/prosa/src/io/stream.rs
+++ b/prosa/src/io/stream.rs
@@ -1022,7 +1022,7 @@ mod tests {
             format!("{target_with_user_password:#}")
         );
         assert_eq!(
-            "TargetSetting { url: Url { scheme: \"https\", cannot_be_a_base: false, username: \"***\", password: Some(\"***\"), host: Some(Domain(\"localhost\")), port: Some(4443), path: \"/v1\" }, ssl: None, connect_timeout: 5000 }",
+            "TargetSetting { url: Url { scheme: \"https\", cannot_be_a_base: false, username: \"***\", password: Some(\"***\"), host: Some(Domain(\"localhost\")), port: Some(4443), path: \"/v1\" }, ssl: None, proxy: None, connect_timeout: 5000 }",
             format!("{target_with_user_password:?}")
         );
 
@@ -1037,7 +1037,7 @@ mod tests {
             format!("{target_with_token:#}")
         );
         assert_eq!(
-            "TargetSetting { url: Url { scheme: \"https\", cannot_be_a_base: false, username: \"\", password: Some(\"***\"), host: Some(Domain(\"localhost\")), port: Some(4443), path: \"/v1\" }, ssl: None, connect_timeout: 5000 }",
+            "TargetSetting { url: Url { scheme: \"https\", cannot_be_a_base: false, username: \"\", password: Some(\"***\"), host: Some(Domain(\"localhost\")), port: Some(4443), path: \"/v1\" }, ssl: None, proxy: None, connect_timeout: 5000 }",
             format!("{target_with_token:?}")
         );
     }

--- a/prosa/src/io/stream.rs
+++ b/prosa/src/io/stream.rs
@@ -21,7 +21,7 @@ use tokio::{
 };
 use url::Url;
 
-use super::{SocketAddr, url_is_ssl};
+use super::{SafeUrl, SocketAddr, get_safe_url, url_is_ssl};
 
 /// ProSA socket object to handle TCP/SSL socket with or without proxy
 #[derive(Debug)]
@@ -167,9 +167,7 @@ impl Stream {
     {
         let ssl = ssl_connector.configure()?.into_ssl(domain)?;
         let mut stream = tokio_openssl::SslStream::new(ssl, tcp_stream)?;
-        if let Err(e) = Pin::new(&mut stream).connect().await
-            && e.code() != openssl::ssl::ErrorCode::ZERO_RETURN
-        {
+        if let Err(e) = Pin::new(&mut stream).connect().await {
             return Err(io::Error::new(
                 io::ErrorKind::Interrupted,
                 format!("Can't connect the OpenSSL socket `{e}`"),
@@ -209,15 +207,17 @@ impl Stream {
         url: &Url,
         ssl_context: &openssl::ssl::SslConnector,
     ) -> Result<Stream, io::Error> {
-        let addrs = url.socket_addrs(|| url.port_or_known_default())?;
+        let addrs = super::lookup_url(url).await?;
         Ok(Stream::OpenSsl(
             Self::create_openssl(
                 TcpStream::connect(&*addrs).await?,
                 ssl_context,
-                url.host_str().ok_or(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!("Can't retrieve host from url `{url}` for ssl"),
-                ))?,
+                url.host_str().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("Can't retrieve host from url `{url}` for ssl"),
+                    )
+                })?,
             )
             .await?,
         ))
@@ -230,7 +230,7 @@ impl Stream {
         port: u16,
         proxy: &Url,
     ) -> Result<TcpStream, io::Error> {
-        let proxy_addrs = proxy.socket_addrs(|| proxy.port_or_known_default())?;
+        let proxy_addrs = super::lookup_url(proxy).await?;
         let mut tcp_stream = TcpStream::connect(&*proxy_addrs).await?;
         if let (username, Some(password)) = (proxy.username(), proxy.password()) {
             if let Err(e) = async_http_proxy::http_connect_tokio_with_basic_auth(
@@ -752,24 +752,18 @@ impl TargetSetting {
         self.ssl.is_some() || url_is_ssl(&self.url)
     }
 
-    /// Getter of the URL with masked inner credential
-    pub fn get_safe_url(&self) -> Url {
-        let mut url = self.url.clone();
-        url.set_query(None);
-        if !url.username().is_empty() {
-            let _ = url.set_username("***");
-        }
-        if url.password().is_some() {
-            let _ = url.set_password(Some("***"));
-        }
-
-        url
+    /// Return a borrowed safe view of the target URL.
+    ///
+    /// Formatting the [`SafeUrl`] masks credentials and omits the query and fragment without
+    /// cloning. Callers can use [`SafeUrl::to_url`] to obtain an owned URL without credentials, or
+    /// [`SafeUrl::to_mask_url`] to obtain one with masked credentials.
+    pub fn get_safe_url(&self) -> SafeUrl<'_> {
+        get_safe_url(&self.url)
     }
 
-    /// Method to get authentication value out of URL username/password
+    /// Build an HTTP authorization value from the target URL credentials.
     ///
-    /// - If user password is provided, it return *Basic* authentication with base64 encoded username:password
-    /// - If only password is provided, it return *Bearer* authentication with the password as token
+    /// Credentials are percent-decoded and validated by [`url_authentication`].
     ///
     /// ```
     /// use url::Url;
@@ -809,7 +803,7 @@ impl TargetSetting {
             .map_err(|e| {
                 io::Error::new(
                     io::ErrorKind::TimedOut,
-                    format!("unix timeout after {e} for {}", self.get_safe_url()),
+                    format!("unix timeout after {e} for {}", self.url.path()),
                 )
             })?;
         }
@@ -850,8 +844,9 @@ impl TargetSetting {
                             io::Error::new(
                                 io::ErrorKind::TimedOut,
                                 format!(
-                                    "openssl with proxy timeout after {e} for {}",
-                                    self.get_safe_url()
+                                    "openssl with proxy timeout after {e} for {} -proxy {}",
+                                    self.get_safe_url(),
+                                    get_safe_url(proxy_url)
                                 ),
                             )
                         })?;
@@ -870,8 +865,9 @@ impl TargetSetting {
                         io::Error::new(
                             io::ErrorKind::TimedOut,
                             format!(
-                                "tcp with proxy timeout after {e} for {}",
-                                self.get_safe_url()
+                                "tcp with proxy timeout after {e} for {} -proxy {}",
+                                self.get_safe_url(),
+                                get_safe_url(proxy_url)
                             ),
                         )
                     })?;
@@ -905,11 +901,10 @@ impl TargetSetting {
             })?;
         }
 
-        let addrs = self.url.socket_addrs(|| self.url.port_or_known_default())?;
-        timeout(
-            Duration::from_millis(self.connect_timeout),
-            Stream::connect_tcp(&*addrs),
-        )
+        timeout(Duration::from_millis(self.connect_timeout), async {
+            let addrs = super::lookup_url(&self.url).await?;
+            Stream::connect_tcp(&*addrs).await
+        })
         .await
         .map_err(|e| {
             io::Error::new(
@@ -935,21 +930,18 @@ impl From<Url> for TargetSetting {
 
 impl fmt::Debug for TargetSetting {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut binding = f.debug_struct("TargetSetting");
-        binding
+        f.debug_struct("TargetSetting")
             .field("url", &self.get_safe_url())
             .field("ssl", &self.ssl)
-            .field("connect_timeout", &self.connect_timeout);
-        if let Some(proxy_url) = &self.proxy {
-            binding.field("proxy", proxy_url);
-        }
-        binding.finish()
+            .field("proxy", &self.proxy.as_ref().map(|p| get_safe_url(p)))
+            .field("connect_timeout", &self.connect_timeout)
+            .finish()
     }
 }
 
 impl fmt::Display for TargetSetting {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut url = self.get_safe_url();
+        let mut url = self.get_safe_url().to_mask_url();
         if self.ssl.is_some() {
             let url_scheme = url.scheme();
             if url_scheme.is_empty() {
@@ -965,7 +957,7 @@ impl fmt::Display for TargetSetting {
 
         if f.alternate() {
             if let Some(proxy_url) = &self.proxy {
-                write!(f, "{url} -proxy {proxy_url}")
+                write!(f, "{url} -proxy {}", get_safe_url(proxy_url))
             } else {
                 write!(f, "{url}")
             }
@@ -999,10 +991,27 @@ mod tests {
         );
 
         let target_with_user_password = TargetSetting::new(
-            Url::parse("https://admin:admin@localhost:4443/v1?user=admin&password=admin")
-                .expect("Target url is invalid"),
+            Url::parse(
+                "https://admin:admin@localhost:4443/v1?user=admin&password=admin#access_token=secret",
+            )
+            .expect("Target url is invalid"),
             None,
             None,
+        );
+        assert_eq!(
+            "https://***:***@localhost:4443/v1",
+            target_with_user_password.get_safe_url().to_string()
+        );
+        assert_eq!(
+            "https://localhost:4443/v1",
+            target_with_user_password.get_safe_url().to_url().as_str()
+        );
+        assert_eq!(
+            "https://***:***@localhost:4443/v1",
+            target_with_user_password
+                .get_safe_url()
+                .to_mask_url()
+                .as_str()
         );
         assert_eq!(
             "https://localhost:4443/v1",
@@ -1013,7 +1022,7 @@ mod tests {
             format!("{target_with_user_password:#}")
         );
         assert_eq!(
-            "TargetSetting { url: Url { scheme: \"https\", cannot_be_a_base: false, username: \"***\", password: Some(\"***\"), host: Some(Domain(\"localhost\")), port: Some(4443), path: \"/v1\", query: None, fragment: None }, ssl: None, connect_timeout: 5000 }",
+            "TargetSetting { url: Url { scheme: \"https\", cannot_be_a_base: false, username: \"***\", password: Some(\"***\"), host: Some(Domain(\"localhost\")), port: Some(4443), path: \"/v1\" }, ssl: None, connect_timeout: 5000 }",
             format!("{target_with_user_password:?}")
         );
 
@@ -1028,7 +1037,7 @@ mod tests {
             format!("{target_with_token:#}")
         );
         assert_eq!(
-            "TargetSetting { url: Url { scheme: \"https\", cannot_be_a_base: false, username: \"\", password: Some(\"***\"), host: Some(Domain(\"localhost\")), port: Some(4443), path: \"/v1\", query: None, fragment: None }, ssl: None, connect_timeout: 5000 }",
+            "TargetSetting { url: Url { scheme: \"https\", cannot_be_a_base: false, username: \"\", password: Some(\"***\"), host: Some(Domain(\"localhost\")), port: Some(4443), path: \"/v1\" }, ssl: None, connect_timeout: 5000 }",
             format!("{target_with_token:?}")
         );
     }

--- a/prosa/src/stub/adaptor.rs
+++ b/prosa/src/stub/adaptor.rs
@@ -167,7 +167,7 @@ where
         _service_name: &str,
         request: M,
     ) -> MaybeAsync<Result<M, ServiceError>> {
-        Ok(request.clone()).into()
+        Ok(request).into()
     }
 }
 

--- a/prosa_book/src/ch01-02-01-observability.md
+++ b/prosa_book/src/ch01-02-01-observability.md
@@ -14,12 +14,12 @@ Of course all configurations can be mixed. You can send your logs to an OpenTele
 
 ### Attributes
 
-For each of your observability data, you can configure attribute that will add labels on your data.
+For each observability signal, you can configure attributes that add labels to the exported data.
 
-These attribute should follow the [OpenTelemetry resource conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md).
+These attributes should follow the [OpenTelemetry resource conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md).
 
-Some of these attributtes are automaticcaly field from ProSA depending of your environment:
-- `service.name` took from _prosa name_
+Some attributes are populated automatically by ProSA depending on the environment:
+- `service.name` from the _ProSA name_
 - `host.arch` if detected from the compilation
 - `os.type` if the OS was detected
 - `service.version` the package version
@@ -34,9 +34,9 @@ observability:
   attributes:
     # Override the service.name from ProSA
     service.name: "my_service"
-    # Overried the version
+    # Override the version
     service.version: "1.0.0"
-  metric: # metrics params
+  metrics: # metrics params
   traces: # traces params
   logs:   # logs params
 ```
@@ -124,6 +124,18 @@ observability:
       endpoint: "http://localhost:4318/v1/logs"
 ```
 
+HTTP OTLP endpoints can carry authorization credentials in their URL:
+
+- `http://user:password@collector/...` produces a Basic authorization header.
+- `http://:token@collector/...` produces a Bearer authorization header.
+
+Username, password, and token values are percent-decoded before the header is built. Percent-encode
+characters that have a special meaning in URL user information, such as `%`, `:`, `@`, `/`, `?`,
+and `#`. Credentials, query parameters, and fragments are redacted from debug output.
+
+> URL credentials are currently applied only to HTTP OTLP exporters. A `grpc://` endpoint does not
+> convert URL credentials into gRPC metadata.
+
 #### Grafana Cloud
 
 You can connect ProSA directly to Grafana Cloud to send metrics, logs, and traces.
@@ -135,14 +147,15 @@ To set it up, you have to:
 - Use a direct connection with a token
 - Decode the base64-encoded basic authorization token from the `Create an Instrumentation Instance`. You'll get an `id:password` to set OTLP credentials with.
 
-> If your token contains a trailing `=`, you need to replace it with `%3D` to ensure a correct URL format.
+> Percent-encode reserved characters in the password. For example, encode a trailing `=` as `%3D`
+> and a literal `%` as `%25`.
 
 With this information, set up your observability stack (look before if you want to set up traces):
 ```yaml
 observability:
   # For the datasource setup
   attributes:
-    - service.name: my-app
+    service.name: my-app
   level: debug
   metrics:
     otlp:

--- a/prosa_book/src/ch01-02-03-stream.md
+++ b/prosa_book/src/ch01-02-03-stream.md
@@ -19,6 +19,13 @@ listener:
 
 > Some server implementations may support the `max_socket` parameter to prevent overload conditions.
 
+When listener settings are logged or formatted, URL credentials are masked and query parameters
+and fragments are omitted. URL paths are preserved, so they should not contain secrets.
+`ListenerSetting::get_safe_url()` returns a borrowed
+[`SafeUrl`](https://docs.rs/prosa/latest/prosa/io/struct.SafeUrl.html), allowing callers to format
+the masked view directly, create an owned URL without credentials with `to_url()`, or create an
+owned URL with masked credentials using `to_mask_url()`.
+
 ## Client
 
 For clients, [`Stream`](https://docs.rs/prosa/latest/prosa/io/stream/enum.Stream.html) typically uses [`TargetSetting`](https://docs.rs/prosa/latest/prosa/io/stream/struct.TargetSetting.html) for configuration.
@@ -35,4 +42,10 @@ stream:
   connect_timeout: 3000
 ```
 
-> The `connect_timeout` setting prevents infinite waits during connection attempts.
+> The `connect_timeout` setting covers address resolution and connection establishment, including
+> proxy and TLS handshakes.
+
+Target and proxy URLs are redacted when settings or connection errors are formatted: credentials
+are masked, while query parameters and fragments are omitted. URL paths are preserved and should
+not contain secrets. `TargetSetting::get_safe_url()` returns the same borrowed `SafeUrl` view, so
+the caller chooses whether to format it or convert it into either form of owned sanitized URL.

--- a/prosa_book/src/ch01-02-04-run.md
+++ b/prosa_book/src/ch01-02-04-run.md
@@ -8,7 +8,7 @@ However, if you want to execute the binary manually, this section explains the a
 ## Command-Line Options
 
 When you run `prosa_binary -h`, you'll see output like the following:
-```
+```text
 Usage: prosa_binary [OPTIONS]
 
 Options:

--- a/prosa_book/src/ch02-01-tvf.md
+++ b/prosa_book/src/ch02-01-tvf.md
@@ -17,7 +17,7 @@ The trait allows you to:
 - ...
 
 Most of the time, when using a component that use TVF, you'll see a generic declaration like:
-```rust,noplayground
+```rust,ignore
 struct StructObject<M>
 where
     M: 'static
@@ -50,7 +50,7 @@ Instead of manually calling `put_*` methods one by one, you can use the `tvf!` p
 
 Create a TVF with key-value pairs using `=>`:
 
-```rust,noplayground
+```rust,ignore
 use prosa_macros::tvf;
 use prosa_utils::msg::simple_string_tvf::SimpleStringTvf;
 
@@ -58,12 +58,16 @@ let message = tvf!(SimpleStringTvf {
     1 => "hello",
     2 => 42,
     3 => 3.14,
+    4 => false,
+    5 => true,
 });
 ```
 
-Integer values are inferred as signed (`i64`) by default. Use type suffixes or `as` casts to specify other types:
+Integer values are inferred as signed (`i64`) by default. Boolean values are stored as bytes:
+`false` becomes `0u8` and `true` becomes `1u8`. Use type suffixes or `as` casts to specify other
+types:
 
-```rust,noplayground
+```rust,ignore
 let message = tvf!(SimpleStringTvf {
     1 => 2,              // signed (i64)
     2 => 4usize,         // also signed
@@ -82,15 +86,19 @@ Use `as Type` to explicitly set the field type:
 | `as Signed`   | `i64`           | `-5 as Signed`                          |
 | `as Float`    | `f64`           | `3.14 as Float`                         |
 | `as Byte`     | `u8`            | `22 as Byte`                            |
+| `as String`   | `String`         | `b"UTF-8 bytes" as String`              |
 | `as Bytes`    | `Bytes`         | `0x01020304 as Bytes`                   |
 | `as Date`     | `NaiveDate`     | `"1995-01-10" as Date`                  |
 | `as DateTime` | `NaiveDateTime` | `"2023-06-05 15:02:00.000" as DateTime` |
+
+Converting a byte-string literal with `as String` happens at compile time and fails compilation if
+the bytes are not valid UTF-8.
 
 ### Lists
 
 Use `[ ]` to create sequential fields indexed starting from 1:
 
-```rust,noplayground
+```rust,ignore
 let list = tvf!(SimpleStringTvf [
     "first element",   // index 1
     "second element",  // index 2
@@ -102,7 +110,7 @@ let list = tvf!(SimpleStringTvf [
 
 Nest TVF structures inside other TVF messages:
 
-```rust,noplayground
+```rust,ignore
 let message = tvf!(SimpleStringTvf {
     1 => 2,
     5 => [
@@ -117,6 +125,8 @@ let message = tvf!(SimpleStringTvf {
         }
     ],
     6 => "1995-01-10" as Date,
+    7 => false,
+    8 => b"UTF-8 bytes" as String,
     200 => "2023-06-05 15:02:00.000" as DateTime,
 });
 ```
@@ -126,7 +136,7 @@ Lists can contain nested maps (`{ }`), and maps can contain nested lists (`[ ]`)
 ## Implement your own TVF
 
 If you have your own internal format, you can implement the TVF trait on your own and expose your TVF struct:
-```rust,noplayground
+```rust,ignore
 impl Tvf for MyOwnTvf {
     // All trait method must be implement here
 }

--- a/prosa_book/src/ch02-01-tvf.md
+++ b/prosa_book/src/ch02-01-tvf.md
@@ -155,7 +155,7 @@ table, use [`IntHashMap`](https://docs.rs/prosa-utils/latest/prosa_utils/hash/ty
 instead of the standard `HashMap`. It uses ProSA's integer hasher and avoids the
 overhead of general-purpose hashing for field lookups.
 
-```rust,noplayground
+```rust,ignore
 use prosa_utils::hash::IntHashMap;
 
 #[derive(Default)]

--- a/prosa_book/src/ch02-02-creation.md
+++ b/prosa_book/src/ch02-02-creation.md
@@ -11,7 +11,7 @@ However, we'll describe good practices for adaptor design to help you understand
 A Processor uses an Adaptor to transform messages, so you typically need a single Adaptor instance to perform this role.
 This adaptor instance must be both `Send` and `Sync`.
 
-```rust,noplayground
+```rust,ignore
 pub trait MyTraitAdaptor<M>
 where
     M: 'static
@@ -53,7 +53,7 @@ flowchart LR
 ```
 
 In this architecture, if your adaptor needs to send external requests originating from internal messages, it may look like this:
-```rust,noplayground
+```rust,ignore
 # pub struct ExternalObjectRequest {}
 # pub struct ExternalObjectResponse {}
 #
@@ -77,7 +77,7 @@ where
 ```
 
 Conversely, if your adaptor needs to handle incoming external requests and provide corresponding internal responses, it may take this shape:
-```rust,noplayground
+```rust,ignore
 # pub struct ExternalObjectRequest {}
 # pub struct ExternalObjectResponse {}
 #
@@ -105,7 +105,7 @@ where
 You can leverage Rust traits to enhance the adaptor specification.
 For example, you can use associated `const` values in traits, such as setting a [user agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/User-Agent).
 
-```rust,noplayground
+```rust,ignore
 pub trait MyTraitAdaptor
 {
     const USER_AGENT: &str;

--- a/prosa_book/src/ch02-04-observability.md
+++ b/prosa_book/src/ch02-04-observability.md
@@ -9,7 +9,7 @@ When you create an adaptor, you may want to generate custom metrics, traces or l
 It is important to understand how to implement these features within ProSA, as ProSA handles much of the integration for you.
 
 For convenience, ProSA re-exports the OpenTelemetry items (`KeyValue`, `metrics`, ...) and the `tracing` macros (`info!`, `debug!`, ...), so for most adaptors you don't need to add any dependency:
-```rust,noplayground
+```rust,ignore
 use prosa::otel::{KeyValue, metrics};
 use prosa::tracing::{debug, error, info, trace, warn};
 ```
@@ -27,7 +27,7 @@ With the meter, you can declare counters, gauges, and more.
 A meter is created from the [main task](https://docs.rs/prosa/latest/prosa/core/main/struct.Main.html#method.meter) or from [processors](https://docs.rs/prosa/latest/prosa/core/proc/struct.ProcParam.html#method.meter).
 You create your metrics using this meter object.
 
-```rust,noplayground
+```rust,ignore
 fn create_metrics<M>(proc_param: prosa::core::proc::ProcParam<M>)
 where
   M: Sized + Clone + Tvf,
@@ -53,7 +53,7 @@ where
 ```
 
 If you want to create asynchronous metrics with regular updates, for example triggered by messages, you can do:
-```rust,noplayground
+```rust,ignore
 fn create_async_metrics<M>(proc_param: prosa::core::proc::ProcParam<M>) -> tokio::sync::watch::Sender<u64>
 where
   M: Sized + Clone + Tvf,
@@ -99,7 +99,7 @@ Tracing create spans and send them automatically to the configured [tracing endp
 Traces is also deeply integrated into ProSA's internal [messaging](https://docs.rs/prosa/latest/prosa/core/msg/trait.Msg.html).
 ProSA messages (which inplement the `prosa::core::msg::Msg` trait) have an internal span that represents the flow of a message through ProSA services.
 
-```rust,noplayground
+```rust,ignore
 fn process_prosa_msg<M>(msg: prosa::core::msg::Msg<M>)
 where
   M: Sized + Clone + Tvf,
@@ -122,7 +122,7 @@ With traces, standalone logs are often less useful, since events are better atta
 However, if you want to log messages, you can use the [log](https://docs.rs/log/latest/log/) crate.
 Like tracing, logging is provisioned automatically with ProSA.
 
-```rust,noplayground
+```rust,ignore
 log::info!("Generate an info log (will not be attached to a trace)");
 ```
 

--- a/prosa_book/src/ch03-01-settings.md
+++ b/prosa_book/src/ch03-01-settings.md
@@ -9,7 +9,7 @@ You'll specify your processor settings object when you create your processor in 
 
 Use [`ProsaConfig`](https://docs.rs/prosa/latest/prosa/core/settings/struct.ProsaConfig.html) to load a ProSA configuration from a file or a directory:
 
-```rust,noplayground
+```rust,ignore
 use prosa::core::settings::ProsaConfig;
 
 let config = ProsaConfig::from_path("prosa.yml")?;
@@ -38,7 +38,7 @@ proc:
 ```
 
 And declare your settings like this in Rust:
-```rust,noplayground
+```rust,ignore
 use serde::{Deserialize, Serialize};
 
 #[proc_settings]
@@ -52,7 +52,7 @@ pub struct MySettings {
 
 Since the `proc_settings` macro adds fields to your struct, it can be tricky to manually implement a default value.
 Fortunately, the macro also supports a custom `Default` implementation that incorporates all required fields:
-```rust,noplayground
+```rust,ignore
 #[proc_settings]
 impl Default for MySettings {
     fn default() -> Self {
@@ -64,7 +64,7 @@ impl Default for MySettings {
 ```
 
 By implementing `Default` for your settings, you can then create a `new` function that uses default parameters, for example:
-```rust,noplayground
+```rust,ignore
 impl MySettings {
     pub fn new(my_param: String) -> MySettings {
         MySettings {

--- a/prosa_book/src/ch03-02-creation.md
+++ b/prosa_book/src/ch03-02-creation.md
@@ -10,7 +10,7 @@ The [Proc module](https://docs.rs/prosa/latest/prosa/core/proc/index.html) conta
 To create a processor, use the [proc macro](https://docs.rs/prosa/latest/prosa/core/proc/attr.proc.html), and implement the [`Proc`](https://docs.rs/prosa/latest/prosa/core/proc/trait.Proc.html) trait.
 
 Given a settings struct named `MyProcSettings` for your processor, your processor struct declaration would look like this:
-```rust,noplayground
+```rust,ignore
 #[proc(settings = MyProcSettings)]
 pub struct MyProc { /* No members here */ }
 ```
@@ -20,7 +20,7 @@ pub struct MyProc { /* No members here */ }
 This is usually not an issue, as you can instantiate and use variables within `internal_run()` (the main loop of the processor).
 
 You can still declare methods on your struct as needed:
-```rust,noplayground
+```rust,ignore
 #[proc]
 impl MyProc
 {
@@ -33,7 +33,7 @@ impl MyProc
 Finally, implement the [`Proc`](https://docs.rs/prosa/latest/prosa/core/proc/trait.Proc.html) trait.
 
 Here's an example skeleton:
-```rust,noplayground
+```rust,ignore
 #[proc]
 impl<A> Proc<A> for MyProc
 where
@@ -83,7 +83,7 @@ Specify in the _where_ clause which traits your adaptor must implement (commonly
 Sometimes, you may want your processor to handle only specific TVF objects, possibly to optimize data handling performance or to provide dedicated logic.
 In these cases, explicitly implement the `Proc` trait for your processor, parameterized by the specific TVF type:
 
-```rust,noplayground
+```rust,ignore
 #[proc]
 impl<A> Proc<A> for MyProc<SimpleStringTvf>
 where

--- a/prosa_book/src/ch03-04-error.md
+++ b/prosa_book/src/ch03-04-error.md
@@ -7,7 +7,7 @@ And even in such occurrence, it is mandatory to have logs about the root cause o
 If there is one advice that we learn implementing ProSA is to avoid using any method that can result in a panic (such as `.unwrap()`) and prefer handling every error correctly.
 Errors should be forwarded to the caller, transformed into an other error type using the `From` trait or handled properly when encountered.
 
-```rust,noplayground
+```rust,ignore
 use thiserror::Error;
 use prosa::core::service::ServiceError;
 

--- a/prosa_book/src/ch03-05-service.md
+++ b/prosa_book/src/ch03-05-service.md
@@ -11,7 +11,7 @@ After declaration, the main task gains access to a queue for sending service req
 However, by default, your processor doesn't listen to any services.
 To start listening to a specific service, call [`add_service_proc()`](https://docs.rs/prosa/latest/prosa/core/proc/struct.ProcParam.html#method.add_service_proc)
 
-```rust,noplayground
+```rust,ignore
 # #[proc]
 # struct MyProc {}
 #
@@ -62,7 +62,7 @@ When designing more complex processors, you may need to handle multiple subtasks
 
 In this case, you can declare multiple listener subtasks, each of which subscribes individually to its relevant service(s).
 
-```rust,noplayground
+```rust,ignore
 # #[proc]
 # struct MyProc {}
 #
@@ -155,7 +155,7 @@ In this case, you can declare multiple listener subtasks, each of which subscrib
 Even if your processor only sends messages, it must be registered to receive responses and errors for your requests using [`add_proc()`](https://docs.rs/prosa/latest/prosa/core/proc/struct.ProcParam.html#method.add_proc).
 After that, you are free to call any services.
 
-```rust,noplayground
+```rust,ignore
 # #[proc]
 # struct MyProc {}
 #
@@ -213,7 +213,7 @@ After that, you are free to call any services.
 If you have multiple subtasks, each must use its own queue to ensure responses are routed to the correct subtask.
 The logic is similar to single senders, but you specify the queue when sending messages.
 
-```rust,noplayground
+```rust,ignore
 # #[proc]
 # struct MyProc {}
 #

--- a/prosa_book/src/ch03-06-events.md
+++ b/prosa_book/src/ch03-06-events.md
@@ -14,7 +14,7 @@ There are three important methods you need to use for this object:
 - [`pull_msg()`](https://docs.rs/prosa/latest/prosa/event/pending/struct.PendingMsgs.html#method.pull) Remove your message when you have received its response and no longer need to check its timeout.
 - [`pull()`](https://docs.rs/prosa/latest/prosa/event/pending/struct.PendingMsgs.html#method.pull) Async method to retrieve all messages that have expired (timed out).
 
-```rust,noplayground
+```rust,ignore
 # #[proc]
 # struct MyProc {}
 #

--- a/prosa_book/src/ch03-09-builtin.md
+++ b/prosa_book/src/ch03-09-builtin.md
@@ -33,7 +33,7 @@ inj-1:
 
 To customize what the injector sends and how it processes responses, implement the `InjAdaptor` trait:
 
-```rust,noplayground
+```rust,ignore
 pub trait InjAdaptor<M>
 where
     M: Tvf + Clone + Debug + Default + Send + Sync + 'static,
@@ -61,7 +61,7 @@ where
 
 The built-in `InjDummyAdaptor` creates minimal messages with `"DUMMY"` in field 1. It is useful for quick smoke tests:
 
-```rust,noplayground
+```rust,ignore
 #[derive(Adaptor)]
 pub struct InjDummyAdaptor {}
 
@@ -86,7 +86,7 @@ where
 The injector exposes a histogram metric `prosa_inj_request_duration` (in seconds) with attributes:
 - `proc`: processor name
 - `service`: target service name
-- `err_code`: `"0"` for success, or the service error code
+- `err_code`: numeric `0` for success, or the numeric service error code
 
 ---
 
@@ -116,7 +116,7 @@ stub-1:
 
 To customize how the stub responds, implement the `StubAdaptor` trait:
 
-```rust,noplayground
+```rust,ignore
 pub trait StubAdaptor<M>
 where
     M: Tvf + Clone + Debug + Default + Send + Sync + 'static,
@@ -141,7 +141,7 @@ The return type `MaybeAsync` lets you choose between synchronous and asynchronou
 
 Return a value directly using `.into()`:
 
-```rust,noplayground
+```rust,ignore
 fn process_request(&self, service_name: &str, request: M) -> MaybeAsync<Result<M, ServiceError>> {
     // Echo the request back
     Ok(request).into()
@@ -152,7 +152,7 @@ fn process_request(&self, service_name: &str, request: M) -> MaybeAsync<Result<M
 
 Use the `maybe_async!` macro for async processing:
 
-```rust,noplayground
+```rust,ignore
 fn process_request(&self, service_name: &str, request: M) -> MaybeAsync<Result<M, ServiceError>> {
     let service_name = service_name.to_string();
     maybe_async!(async move {
@@ -169,9 +169,9 @@ fn process_request(&self, service_name: &str, request: M) -> MaybeAsync<Result<M
 
 **StubParotAdaptor** — echoes the request back as-is (synchronous):
 
-```rust,noplayground
+```rust,ignore
 fn process_request(&self, _service_name: &str, request: M) -> MaybeAsync<Result<M, ServiceError>> {
-    Ok(request.clone()).into()
+    Ok(request).into()
 }
 ```
 
@@ -187,7 +187,7 @@ stub_1:
 sleep_ms: 250
 ```
 
-```rust,noplayground
+```rust,ignore
 fn process_request(&self, _service_name: &str, request: M) -> MaybeAsync<Result<M, ServiceError>> {
     let sleep_duration = std::time::Duration::from_millis(
         self.sleep_ms.load(std::sync::atomic::Ordering::Relaxed),

--- a/prosa_macros/Cargo.toml
+++ b/prosa_macros/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 unwrap_used = "deny"
 
 [dependencies]
-syn = { version = "2", features = ["full"] }
+syn = { version = "3", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
 chrono.workspace = true

--- a/prosa_macros/src/settings.rs
+++ b/prosa_macros/src/settings.rs
@@ -9,7 +9,7 @@ fn add_default_member<F>(mut item_impl: ItemImpl, func: F) -> syn::parse::Result
 where
     F: Fn(&mut syn::ExprStruct) -> syn::parse::Result<()>,
 {
-    if let (Some((_, trait_path, _)), syn::Type::Path(self_path)) =
+    if let (Some((trait_path, _)), syn::Type::Path(self_path)) =
         (&item_impl.trait_, item_impl.self_ty.as_ref())
     {
         // Only consider Default trait impl

--- a/prosa_macros/src/tvf/literal.rs
+++ b/prosa_macros/src/tvf/literal.rs
@@ -134,7 +134,31 @@ pub(crate) fn convert_literal(
             }
         },
         ValueType::Bytes => match output_type {
-            ValueType::String => quote! [ ::std::str::from_utf8( #literal.as_ref() ).unwrap() ],
+            ValueType::String => {
+                let byte_string = match parse_quote! [ #literal ] {
+                    syn::Expr::Lit(literal) => match literal.lit {
+                        Lit::ByteStr(byte_string) => byte_string,
+                        _ => {
+                            return Err(Error::new_spanned(
+                                literal,
+                                "Expected a byte string literal.",
+                            ));
+                        }
+                    },
+                    expression => {
+                        return Err(Error::new_spanned(
+                            expression,
+                            "Expected a byte string literal.",
+                        ));
+                    }
+                };
+                let value = byte_string.value();
+                let string = std::str::from_utf8(&value).map_err(|_| {
+                    Error::new_spanned(literal, "Byte string contains invalid UTF-8.")
+                })?;
+                let string = syn::LitStr::new(string, literal.span());
+                quote! [ #string ]
+            }
             _ => {
                 return Err(Error::new_spanned(
                     literal,

--- a/prosa_macros/src/tvf/value.rs
+++ b/prosa_macros/src/tvf/value.rs
@@ -115,7 +115,7 @@ pub(crate) fn generate_value(
             // check if the identifier is a boolean
             match ident.to_string().as_str() {
                 "true" => Ok((quote![1u8], output_type.unwrap_or(ValueType::Byte))),
-                "false" => Ok((quote![1u8], output_type.unwrap_or(ValueType::Byte))),
+                "false" => Ok((quote![0u8], output_type.unwrap_or(ValueType::Byte))),
                 _ => {
                     if let Some(output_type) = output_type {
                         Ok((quote![#ident], output_type))

--- a/prosa_macros/tests/tvf.rs
+++ b/prosa_macros/tests/tvf.rs
@@ -23,12 +23,21 @@ mod macro_tests {
                 }
             ],
             6 => "1995-01-10" as Date,
+            7 => false,
+            8 => true,
+            9 => b"string from bytes" as String,
             200 => "2023-06-05 15:02:00.000" as DateTime,
         });
 
-        assert_eq!(5, buffer.len());
+        assert_eq!(8, buffer.len());
         assert_eq!(Ok(2), buffer.get_unsigned(1));
         assert_eq!(Ok(4), buffer.get_signed(3));
+        assert_eq!(Ok(0), buffer.get_byte(7));
+        assert_eq!(Ok(1), buffer.get_byte(8));
+        assert_eq!(
+            Ok("string from bytes"),
+            buffer.get_string(9).map(|s| s.to_string()).as_deref()
+        );
 
         let subbuffer = buffer.get_buffer(5).expect("TVF should have a sub buffer");
         assert_eq!(Ok(1u64), subbuffer.get_unsigned(1));

--- a/prosa_utils/Cargo.toml
+++ b/prosa_utils/Cargo.toml
@@ -12,7 +12,7 @@ include.workspace = true
 [features]
 default = ["msg", "config", "config-openssl", "config-observability"]
 msg = []
-config = ["dep:glob","dep:serde","dep:serde_yaml", "dep:base64", "dep:uuid"]
+config = ["dep:glob","dep:serde","dep:serde_yaml", "dep:base64", "dep:percent-encoding", "dep:uuid"]
 config-openssl = ["config", "dep:openssl"]
 config-openssl-vendored = ["config-openssl", "openssl/vendored"]
 config-observability = ["dep:log", "dep:tracing-core", "dep:tracing-subscriber", "dep:tracing-opentelemetry", "dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-stdout", "dep:opentelemetry-otlp", "dep:opentelemetry-appender-tracing"]
@@ -42,6 +42,7 @@ glob = { version = "0.3", optional = true }
 serde = { workspace = true, optional = true }
 serde_yaml = { version = "0.9", optional = true }
 base64 = { version = "0.22", optional = true }
+percent-encoding = { version = "2", optional = true }
 uuid = { version = "1", optional = true, features = ["v1", "v4"] }
 
 # Config OpenSSL

--- a/prosa_utils/src/config.rs
+++ b/prosa_utils/src/config.rs
@@ -6,9 +6,7 @@
 
 use std::{io, path::PathBuf, process::Command};
 
-use base64::{Engine as _, engine::general_purpose::STANDARD};
 use thiserror::Error;
-use url::Url;
 use uuid::Uuid;
 
 // Feature openssl or rusttls,...
@@ -21,6 +19,9 @@ pub mod observability;
 // Feature tracing
 #[cfg(feature = "config-observability")]
 pub mod tracing;
+
+pub mod url;
+pub use url::url_authentication;
 
 /// Error define for configuration object
 #[derive(Debug, Error)]
@@ -144,40 +145,6 @@ pub fn hostid() -> String {
     }
 }
 
-/// Method to get authentication value out of URL username/password
-///
-/// - If user password is provided, it return *Basic* authentication with base64 encoded username:password
-/// - If only password is provided, it return *Bearer* authentication with the password as token
-///
-/// ```
-/// use url::Url;
-/// use prosa_utils::config::url_authentication;
-///
-/// let basic_auth_target = Url::parse("http://user:pass@localhost:8080").unwrap();
-/// assert_eq!(Some(String::from("Basic dXNlcjpwYXNz")), url_authentication(&basic_auth_target));
-///
-/// let bearer_auth_target = Url::parse("http://:token@localhost:8080").unwrap();
-/// assert_eq!(Some(String::from("Bearer token")), url_authentication(&bearer_auth_target));
-/// ```
-pub fn url_authentication(url: &Url) -> Option<String> {
-    if let Some(password) = url.password().map(|p| {
-        p.replace("%24", "$")
-            .replace("%26", "&")
-            .replace("%3D", "=")
-    }) {
-        if url.username().is_empty() {
-            Some(format!("Bearer {password}"))
-        } else {
-            Some(format!(
-                "Basic {}",
-                STANDARD.encode(format!("{}:{}", url.username(), password))
-            ))
-        }
-    } else {
-        None
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -202,35 +169,5 @@ mod tests {
     fn test_hostid() {
         let host_id = hostid();
         assert_eq!(host_id.len(), 36);
-    }
-
-    #[test]
-    fn test_url_authentication_basic() {
-        let basic_auth_target = Url::parse("http://user:pass@localhost:8080")
-            .expect("Basic auth target URL should be valid");
-        assert_eq!(
-            Some(String::from("Basic dXNlcjpwYXNz")),
-            url_authentication(&basic_auth_target)
-        );
-    }
-
-    #[test]
-    fn test_url_safe_authentication_basic() {
-        let basic_auth_target = Url::parse("http://user:$ab&cd=@localhost:8080")
-            .expect("Basic auth target URL should be valid");
-        assert_eq!(
-            Some(String::from("Basic dXNlcjokYWImY2Q9")),
-            url_authentication(&basic_auth_target)
-        );
-    }
-
-    #[test]
-    fn test_url_authentication_bearer() {
-        let bearer_auth_target = Url::parse("http://:token@localhost:8080")
-            .expect("Basic auth target URL should be valid");
-        assert_eq!(
-            Some(String::from("Bearer token")),
-            url_authentication(&bearer_auth_target)
-        );
     }
 }

--- a/prosa_utils/src/config/observability.rs
+++ b/prosa_utils/src/config/observability.rs
@@ -8,17 +8,17 @@ use opentelemetry_sdk::{
     trace::{SdkTracerProvider, Tracer},
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, fmt, time::Duration};
 use tracing_subscriber::{filter, prelude::*};
 use tracing_subscriber::{layer::SubscriberExt, util::TryInitError};
 use url::Url;
 
-use crate::config::url_authentication;
+use crate::config::url::{get_safe_url, url_authentication};
 
 use super::tracing::{TelemetryFilter, TelemetryLevel};
 
 /// Configuration struct of an **O**pen **T**e**l**emetry **P**rotocol Exporter
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub(crate) struct OTLPExporterCfg {
     pub(crate) level: Option<TelemetryLevel>,
     endpoint: Url,
@@ -55,7 +55,11 @@ impl OTLPExporterCfg {
     pub(crate) fn get_header(&self) -> HashMap<String, String> {
         let mut headers = HashMap::with_capacity(1);
         if let Some(authorization) = url_authentication(&self.endpoint) {
-            headers.insert("Authorization".to_string(), authorization);
+            // `WithHttpConfig::with_headers` URL-decodes values, so preserve literal `%`.
+            headers.insert(
+                "Authorization".to_string(),
+                authorization.replace('%', "%25"),
+            );
         }
         headers
     }
@@ -85,6 +89,19 @@ impl Default for OTLPExporterCfg {
             endpoint: Url::parse("grpc://localhost:4317").expect("default OTLP address is invalid"),
             timeout_sec: None,
         }
+    }
+}
+
+impl fmt::Debug for OTLPExporterCfg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OTLPExporterCfg")
+            .field("level", &self.level)
+            .field(
+                "endpoint",
+                &get_safe_url(&self.endpoint).without_credentials(),
+            )
+            .field("timeout_sec", &self.timeout_sec)
+            .finish()
     }
 }
 
@@ -681,5 +698,43 @@ impl Default for Observability {
                 }),
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn otlp_http_authorization_preserves_literal_percent_triplets() {
+        let config = OTLPExporterCfg {
+            level: None,
+            endpoint: Url::parse("http://:token%2541@localhost:4318")
+                .expect("OTLP endpoint should be valid"),
+            timeout_sec: None,
+        };
+
+        assert_eq!(
+            Some("Bearer token%2541"),
+            config.get_header().get("Authorization").map(String::as_str)
+        );
+    }
+
+    #[test]
+    fn otlp_debug_redacts_url_secrets() {
+        let config = OTLPExporterCfg {
+            level: None,
+            endpoint: Url::parse(
+                "http://user:password@localhost:4318/v1?token=secret#access_token=secret",
+            )
+            .expect("OTLP endpoint should be valid"),
+            timeout_sec: None,
+        };
+
+        let debug = format!("{config:?}");
+        assert!(debug.contains("http://localhost:4318/v1"));
+        assert!(!debug.contains("user"));
+        assert!(!debug.contains("password"));
+        assert!(!debug.contains("secret"));
     }
 }

--- a/prosa_utils/src/config/ssl.rs
+++ b/prosa_utils/src/config/ssl.rs
@@ -139,7 +139,10 @@ pub trait SslConfigContext<C, S> {
     fn init_tls_server_context(&self, host: Option<&str>) -> Result<S, ConfigError>;
 }
 
-/// SSL configuration for socket
+/// SSL configuration for sockets.
+///
+/// Its [`Debug`](fmt::Debug) implementation deliberately omits the private-key or PKCS#12
+/// passphrase.
 ///
 /// Client SSL socket
 /// ```
@@ -147,8 +150,6 @@ pub trait SslConfigContext<C, S> {
 /// use std::pin::Pin;
 /// use tokio::net::TcpStream;
 /// use tokio_openssl::SslStream;
-/// # #[cfg(feature="config-openssl")]
-/// use openssl::ssl::{ErrorCode, Ssl, SslMethod, SslVerifyMode};
 /// use prosa_utils::config::ssl::{SslConfig, SslConfigContext};
 ///
 /// # #[cfg(feature="config-openssl")]
@@ -159,11 +160,10 @@ pub trait SslConfigContext<C, S> {
 ///     if let Ok(mut ssl_context_builder) = client_config.init_tls_client_context() {
 ///         let ssl = ssl_context_builder.build().configure().unwrap().into_ssl("localhost").unwrap();
 ///         let mut stream = SslStream::new(ssl, stream).unwrap();
-///         if let Err(e) = Pin::new(&mut stream).connect().await {
-///             if e.code() != ErrorCode::ZERO_RETURN {
-///                 eprintln!("Can't connect the client: {}", e);
-///             }
-///         }
+///         Pin::new(&mut stream)
+///             .connect()
+///             .await
+///             .map_err(|e| io::Error::other(format!("Can't connect the client: {e}")))?;
 ///
 ///         // SSL stream ...
 ///     }
@@ -179,7 +179,7 @@ pub trait SslConfigContext<C, S> {
 /// use tokio::net::TcpListener;
 /// use tokio_openssl::SslStream;
 /// # #[cfg(feature="config-openssl")]
-/// use openssl::ssl::{ErrorCode, Ssl, SslMethod, SslVerifyMode};
+/// use openssl::ssl::{Ssl, SslVerifyMode};
 /// use prosa_utils::config::ssl::{SslConfig, SslConfigContext};
 ///
 /// # #[cfg(feature="config-openssl")]
@@ -196,9 +196,8 @@ pub trait SslConfigContext<C, S> {
 ///             let ssl = Ssl::new(&ssl_context.context()).unwrap();
 ///             let mut stream = SslStream::new(ssl, stream).unwrap();
 ///             if let Err(e) = Pin::new(&mut stream).accept().await {
-///                 if e.code() != ErrorCode::ZERO_RETURN {
-///                     eprintln!("Can't accept the client {}: {}", cli_addr, e);
-///                 }
+///                 eprintln!("Can't accept the client {cli_addr}: {e}");
+///                 continue;
 ///             }
 ///
 ///             // SSL stream ...
@@ -208,7 +207,7 @@ pub trait SslConfigContext<C, S> {
 ///     Ok(())
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Deserialize, Serialize)]
 pub struct SslConfig {
     /// SSL store certificate to verify the remote certificate
     store: Option<Store>,
@@ -319,6 +318,20 @@ impl Default for SslConfig {
             modern_security: Self::default_modern_security(),
             ssl_timeout: Self::default_ssl_timeout(),
         }
+    }
+}
+
+impl fmt::Debug for SslConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SslConfig")
+            .field("store", &self.store)
+            .field("pkcs12", &self.pkcs12)
+            .field("cert", &self.cert)
+            .field("key", &self.key)
+            .field("alpn", &self.alpn)
+            .field("modern_security", &self.modern_security)
+            .field("ssl_timeout", &self.ssl_timeout)
+            .finish()
     }
 }
 
@@ -448,6 +461,10 @@ tL4ndQavEi51mI38AjEAi/V3bNTIZargCyzuFJ0nN6T5U6VR5CmD1/iQMVtCnwr1
     #[test]
     fn test_tls_server_context() {
         let ssl_config = SslConfig::default();
+        assert_eq!(
+            "SslConfig { store: None, pkcs12: None, cert: None, key: None, alpn: [], modern_security: true, ssl_timeout: 3000 }",
+            format!("{ssl_config:?}")
+        );
         let ssl_acceptor = ssl_config
             .init_tls_server_context(None)
             .expect("The TLS server context should be init")
@@ -456,5 +473,20 @@ tL4ndQavEi51mI38AjEAi/V3bNTIZargCyzuFJ0nN6T5U6VR5CmD1/iQMVtCnwr1
         // Check for self signed certificate
         assert!(ssl_acceptor.context().private_key().is_some());
         assert!(ssl_acceptor.context().certificate().is_some());
+    }
+
+    #[test]
+    fn ssl_config_debug_redacts_passphrase() {
+        let ssl_config = SslConfig::new_cert_key(
+            "cert.pem".into(),
+            "key.pem".into(),
+            Some("sensitive-passphrase".into()),
+        );
+
+        let debug = format!("{ssl_config:?}");
+        assert!(debug.contains("cert.pem"));
+        assert!(debug.contains("key.pem"));
+        assert!(!debug.contains("sensitive-passphrase"));
+        assert!(!debug.contains("passphrase"));
     }
 }

--- a/prosa_utils/src/config/ssl/openssl.rs
+++ b/prosa_utils/src/config/ssl/openssl.rs
@@ -399,7 +399,7 @@ impl SslConfigContext<SslConnectorBuilder, SslAcceptorBuilder> for SslConfig {
     /// use std::pin::Pin;
     /// use tokio::net::TcpStream;
     /// use tokio_openssl::SslStream;
-    /// use openssl::ssl::{ErrorCode, Ssl, SslMethod, SslVerifyMode};
+    /// use openssl::ssl::Ssl;
     /// use prosa_utils::config::ssl::{SslConfig, SslConfigContext};
     ///
     /// async fn client() -> Result<(), io::Error> {
@@ -410,11 +410,10 @@ impl SslConfigContext<SslConnectorBuilder, SslAcceptorBuilder> for SslConfig {
     ///         let ssl_context = ssl_context_builder.build();
     ///         let ssl = Ssl::new(&ssl_context.context()).unwrap();
     ///         let mut stream = SslStream::new(ssl, stream).unwrap();
-    ///         if let Err(e) = Pin::new(&mut stream).connect().await {
-    ///             if e.code() != ErrorCode::ZERO_RETURN {
-    ///                 eprintln!("Can't connect the client: {}", e);
-    ///             }
-    ///         }
+    ///         Pin::new(&mut stream)
+    ///             .connect()
+    ///             .await
+    ///             .map_err(|e| io::Error::other(format!("Can't connect the client: {e}")))?;
     ///
     ///         // SSL stream ...
     ///     }
@@ -435,7 +434,7 @@ impl SslConfigContext<SslConnectorBuilder, SslAcceptorBuilder> for SslConfig {
     /// use std::pin::Pin;
     /// use tokio::net::TcpListener;
     /// use tokio_openssl::SslStream;
-    /// use openssl::ssl::{ErrorCode, Ssl, SslMethod, SslVerifyMode};
+    /// use openssl::ssl::{Ssl, SslVerifyMode};
     /// use prosa_utils::config::ssl::{SslConfig, SslConfigContext};
     ///
     /// async fn server() -> Result<(), io::Error> {
@@ -451,9 +450,8 @@ impl SslConfigContext<SslConnectorBuilder, SslAcceptorBuilder> for SslConfig {
     ///             let ssl = Ssl::new(&ssl_context.context()).unwrap();
     ///             let mut stream = SslStream::new(ssl, stream).unwrap();
     ///             if let Err(e) = Pin::new(&mut stream).accept().await {
-    ///                 if e.code() != ErrorCode::ZERO_RETURN {
-    ///                     eprintln!("Can't accept the client {}: {}", cli_addr, e);
-    ///                 }
+    ///                 eprintln!("Can't accept the client {cli_addr}: {e}");
+    ///                 continue;
     ///             }
     ///
     ///             // SSL stream ...

--- a/prosa_utils/src/config/url.rs
+++ b/prosa_utils/src/config/url.rs
@@ -1,0 +1,333 @@
+//! URL authentication and safe-formatting utilities.
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use percent_encoding::percent_decode_str;
+use std::fmt;
+
+use ::url::{Position, Url};
+
+static CREDENTIAL_MASK: &str = "***";
+
+/// Borrowed URL view for safe logging and display.
+///
+/// [`Display`](fmt::Display) and [`Debug`](fmt::Debug) mask URL credentials and omit the query
+/// and fragment without cloning the underlying [`Url`]. [`SafeUrl::to_url`] returns an owned URL
+/// with credentials removed, while [`SafeUrl::to_mask_url`] returns one with masked credentials.
+///
+/// The URL path is preserved and can still contain sensitive information. Callers must avoid
+/// putting secrets in paths or apply additional application-specific redaction.
+#[derive(Clone, Copy)]
+pub struct SafeUrl<'a> {
+    url: &'a Url,
+}
+
+impl<'a> SafeUrl<'a> {
+    /// Create a borrowed URL view that masks credentials and omits query and fragment when
+    /// formatted.
+    pub fn new(url: &'a Url) -> Self {
+        Self { url }
+    }
+
+    /// Return an owned URL without credentials, query, or fragment.
+    pub fn to_url(&self) -> Url {
+        let mut url = self.url.clone();
+        url.set_query(None);
+        url.set_fragment(None);
+        if !url.username().is_empty() {
+            let _ = url.set_username("");
+        }
+        if url.password().is_some() {
+            let _ = url.set_password(None);
+        }
+
+        url
+    }
+
+    /// Return an owned URL with masked credentials and without query or fragment.
+    pub fn to_mask_url(&self) -> Url {
+        let mut url = self.url.clone();
+        url.set_query(None);
+        url.set_fragment(None);
+        if !url.username().is_empty() {
+            let _ = url.set_username(CREDENTIAL_MASK);
+        }
+        if url.password().is_some() {
+            let _ = url.set_password(Some(CREDENTIAL_MASK));
+        }
+
+        url
+    }
+
+    #[cfg(feature = "config-observability")]
+    pub(crate) fn without_credentials(self) -> UrlWithoutCredentials<'a> {
+        UrlWithoutCredentials { url: self.url }
+    }
+}
+
+#[cfg(feature = "config-observability")]
+#[derive(Clone, Copy)]
+pub(crate) struct UrlWithoutCredentials<'a> {
+    url: &'a Url,
+}
+
+#[cfg(feature = "config-observability")]
+impl fmt::Display for UrlWithoutCredentials<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.url[..Position::BeforeUsername])?;
+        f.write_str(&self.url[Position::BeforeHost..Position::AfterPath])
+    }
+}
+
+#[cfg(feature = "config-observability")]
+impl fmt::Debug for UrlWithoutCredentials<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl fmt::Display for SafeUrl<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.url[..Position::BeforeUsername])?;
+
+        let has_username = !self.url.username().is_empty();
+        let has_password = self.url.password().is_some();
+
+        if has_username {
+            f.write_str(CREDENTIAL_MASK)?;
+        }
+        if has_password {
+            f.write_str(":")?;
+            f.write_str(CREDENTIAL_MASK)?;
+        }
+        if has_username || has_password {
+            f.write_str("@")?;
+        }
+
+        f.write_str(&self.url[Position::BeforeHost..Position::AfterPath])
+    }
+}
+
+impl fmt::Debug for SafeUrl<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let username = if self.url.username().is_empty() {
+            ""
+        } else {
+            CREDENTIAL_MASK
+        };
+        let password = self.url.password().map(|_| CREDENTIAL_MASK);
+
+        f.debug_struct("Url")
+            .field("scheme", &self.url.scheme())
+            .field("cannot_be_a_base", &self.url.cannot_be_a_base())
+            .field("username", &username)
+            .field("password", &password)
+            .field("host", &self.url.host())
+            .field("port", &self.url.port())
+            .field("path", &self.url.path())
+            .finish()
+    }
+}
+
+/// Return a borrowed URL view with masked credentials and without query or fragment.
+///
+/// Formatting the returned view does not clone or reparse the URL. Use [`SafeUrl::to_url`] when an
+/// owned URL without credentials is required, or [`SafeUrl::to_mask_url`] when the owned URL must
+/// retain masked user information.
+///
+/// ```
+/// use prosa_utils::config::url::get_safe_url;
+/// use url::Url;
+///
+/// let url =
+///     Url::parse("https://admin:secret@localhost:4443/v1?token=secret#access_token=secret")
+///         .unwrap();
+/// let safe_url = get_safe_url(&url);
+///
+/// assert_eq!(safe_url.to_string(), "https://***:***@localhost:4443/v1");
+/// assert_eq!(safe_url.to_url().as_str(), "https://localhost:4443/v1");
+/// assert_eq!(safe_url.to_mask_url().as_str(), "https://***:***@localhost:4443/v1");
+/// ```
+pub fn get_safe_url(url: &Url) -> SafeUrl<'_> {
+    SafeUrl::new(url)
+}
+
+/// Build an HTTP authorization value from URL credentials.
+///
+/// URL percent-encoding is decoded before constructing the authentication value. Basic
+/// authentication usernames containing a decoded `:` are rejected because the character
+/// separates the username and password. Bearer credentials that are not valid ASCII HTTP header
+/// values are rejected.
+///
+/// - A non-empty username and password produce Basic authentication.
+/// - An empty username and password produce Bearer authentication using the password as the token.
+/// - A URL without a password produces `None`.
+///
+/// ```
+/// use url::Url;
+/// use prosa_utils::config::url::url_authentication;
+///
+/// let basic_auth_target = Url::parse("http://user:pass@localhost:8080").unwrap();
+/// assert_eq!(Some(String::from("Basic dXNlcjpwYXNz")), url_authentication(&basic_auth_target));
+///
+/// let bearer_auth_target = Url::parse("http://:token@localhost:8080").unwrap();
+/// assert_eq!(Some(String::from("Bearer token")), url_authentication(&bearer_auth_target));
+/// ```
+pub fn url_authentication(url: &Url) -> Option<String> {
+    let password = url.password()?;
+
+    if url.username().is_empty() {
+        let password = percent_decode_str(password).decode_utf8().ok()?;
+        if !password
+            .bytes()
+            .all(|byte| byte == b'\t' || (b' '..=b'~').contains(&byte))
+        {
+            return None;
+        }
+        Some(format!("Bearer {password}"))
+    } else {
+        let username = percent_decode_str(url.username()).collect::<Vec<_>>();
+        if username.contains(&b':') {
+            return None;
+        }
+
+        let mut credentials = Vec::with_capacity(username.len() + password.len() + 1);
+        credentials.extend(username);
+        credentials.push(b':');
+        credentials.extend(percent_decode_str(password));
+        Some(format!("Basic {}", STANDARD.encode(credentials)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_safe_url_display() {
+        let url =
+            Url::parse("https://admin:secret@localhost:4443/v1?token=secret#access_token=secret")
+                .expect("URL should be valid");
+
+        assert_eq!(
+            "https://***:***@localhost:4443/v1",
+            get_safe_url(&url).to_string()
+        );
+    }
+
+    #[test]
+    fn test_safe_url_debug() {
+        let url =
+            Url::parse("https://admin:secret@localhost:4443/v1?token=secret#access_token=secret")
+                .expect("URL should be valid");
+
+        assert_eq!(
+            "Url { scheme: \"https\", cannot_be_a_base: false, username: \"***\", password: Some(\"***\"), host: Some(Domain(\"localhost\")), port: Some(4443), path: \"/v1\" }",
+            format!("{:?}", get_safe_url(&url))
+        );
+    }
+
+    #[test]
+    fn test_safe_url_to_url() {
+        let url =
+            Url::parse("https://admin:secret@localhost:4443/v1?token=secret#access_token=secret")
+                .expect("URL should be valid");
+
+        assert_eq!(
+            "https://localhost:4443/v1",
+            get_safe_url(&url).to_url().as_str()
+        );
+        assert_eq!(
+            "https://admin:secret@localhost:4443/v1?token=secret#access_token=secret",
+            url.as_str()
+        );
+    }
+
+    #[test]
+    fn test_safe_url_to_mask_url() {
+        let url =
+            Url::parse("https://admin:secret@localhost:4443/v1?token=secret#access_token=secret")
+                .expect("URL should be valid");
+
+        assert_eq!(
+            "https://***:***@localhost:4443/v1",
+            get_safe_url(&url).to_mask_url().as_str()
+        );
+        assert_eq!(
+            "https://admin:secret@localhost:4443/v1?token=secret#access_token=secret",
+            url.as_str()
+        );
+    }
+
+    #[test]
+    fn test_safe_url_bearer_authentication() {
+        let url = Url::parse("https://:token@localhost:4443/v1")
+            .expect("Bearer authentication URL should be valid");
+
+        assert_eq!(
+            "https://:***@localhost:4443/v1",
+            get_safe_url(&url).to_string()
+        );
+        assert_eq!(
+            "Url { scheme: \"https\", cannot_be_a_base: false, username: \"\", password: Some(\"***\"), host: Some(Domain(\"localhost\")), port: Some(4443), path: \"/v1\" }",
+            format!("{:?}", get_safe_url(&url))
+        );
+    }
+
+    #[test]
+    fn test_url_authentication_basic() {
+        let basic_auth_target = Url::parse("http://user:pass@localhost:8080")
+            .expect("Basic auth target URL should be valid");
+        assert_eq!(
+            Some(String::from("Basic dXNlcjpwYXNz")),
+            url_authentication(&basic_auth_target)
+        );
+    }
+
+    #[test]
+    fn test_url_encoded_authentication_basic() {
+        let basic_auth_target = Url::parse("http://us%40er:p%25%3A%C3%A4ss@localhost:8080")
+            .expect("Basic auth target URL should be valid");
+        assert_eq!(
+            Some(format!("Basic {}", STANDARD.encode("us@er:p%:äss"))),
+            url_authentication(&basic_auth_target)
+        );
+    }
+
+    #[test]
+    fn test_url_authentication_rejects_colon_in_basic_username() {
+        let basic_auth_target = Url::parse("http://us%3Aer:password@localhost:8080")
+            .expect("Basic auth target URL should be valid");
+        assert_eq!(None, url_authentication(&basic_auth_target));
+    }
+
+    #[test]
+    fn test_url_authentication_bearer() {
+        let bearer_auth_target = Url::parse("http://:token%25%40%3A@localhost:8080")
+            .expect("Bearer auth target URL should be valid");
+        assert_eq!(
+            Some(String::from("Bearer token%@:")),
+            url_authentication(&bearer_auth_target)
+        );
+    }
+
+    #[test]
+    fn test_url_authentication_rejects_control_characters_in_bearer() {
+        let bearer_auth_target = Url::parse("http://:token%0D%0AX-Test%3Ayes@localhost:8080")
+            .expect("Bearer auth target URL should be valid");
+        assert_eq!(None, url_authentication(&bearer_auth_target));
+    }
+
+    #[test]
+    fn test_url_authentication_rejects_non_ascii_bearer() {
+        let bearer_auth_target = Url::parse("http://:token%E2%9C%93@localhost:8080")
+            .expect("Bearer auth target URL should be valid");
+        assert_eq!(None, url_authentication(&bearer_auth_target));
+    }
+
+    #[test]
+    fn test_url_authentication_rejects_non_utf8_bearer() {
+        let bearer_auth_target = Url::parse("http://:%FF@localhost:8080")
+            .expect("Bearer auth target URL should be valid");
+        assert_eq!(None, url_authentication(&bearer_auth_target));
+    }
+}


### PR DESCRIPTION
- Avoid credential leaking through `Url` with new object `SafeUrl`
- Improve password parsing in `Url`, use `percent-encoding` crate
- Fix TLS connection, don't treat `ZERO_RETURN` as success
- Do async DNS resolution to avoir blocking thread
- Fix TVF macro false, and UTF-8 processing
- Improve performance with `get_or_insert_with` and `ok_or_else`, to not build unused objects
- ProSA book fix to match what the code is actually doing

Small other fixes are also not listed here. They are mainly for performance.