### PR TITLE
serde feature flag for TVF trait types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 ]
 
 [workspace.dependencies]
-prosa-utils = { version = "0.5.0", path = "prosa_utils" }
+prosa-utils = { version = "0.5.1", path = "prosa_utils" }
 prosa-macros = { version = "0.5.0", path = "prosa_macros" }
 thiserror = "2"
 simple-mermaid = "0.2"

--- a/prosa_utils/Cargo.toml
+++ b/prosa_utils/Cargo.toml
@@ -12,7 +12,7 @@ include.workspace = true
 [features]
 default = ["msg", "config", "config-openssl", "config-observability"]
 msg = []
-msg-serde = ["dep:serde", "chrono/serde", "bytes/serde"]
+msg-serde = ["msg", "dep:serde", "chrono/serde", "bytes/serde"]
 config = ["dep:glob","dep:serde","dep:serde_yaml", "dep:base64", "dep:percent-encoding", "dep:uuid"]
 config-openssl = ["config", "dep:openssl"]
 config-openssl-vendored = ["config-openssl", "openssl/vendored"]

--- a/prosa_utils/Cargo.toml
+++ b/prosa_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prosa-utils"
-version = "0.5.0"
+version = "0.5.1"
 authors.workspace = true
 description = "ProSA utils"
 homepage.workspace = true
@@ -12,6 +12,7 @@ include.workspace = true
 [features]
 default = ["msg", "config", "config-openssl", "config-observability"]
 msg = []
+msg-serde = ["dep:serde", "chrono/serde", "bytes/serde"]
 config = ["dep:glob","dep:serde","dep:serde_yaml", "dep:base64", "dep:percent-encoding", "dep:uuid"]
 config-openssl = ["config", "dep:openssl"]
 config-openssl-vendored = ["config-openssl", "openssl/vendored"]

--- a/prosa_utils/src/msg.rs
+++ b/prosa_utils/src/msg.rs
@@ -6,3 +6,5 @@ pub mod tvf;
 // re-export types used by TVF trait
 pub use bytes;
 pub use chrono;
+#[cfg(feature = "msg-serde")]
+pub use serde;

--- a/prosa_utils/src/msg/simple_string_tvf.rs
+++ b/prosa_utils/src/msg/simple_string_tvf.rs
@@ -12,6 +12,7 @@ use std::borrow::Cow;
 
 /// Struct that define a simple string TVF
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "msg-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SimpleStringTvf {
     fields: IntHashMap<usize, String>,
 }


### PR DESCRIPTION
To interface the **TVF** trait with `serde` we need to enable the `serde` feature flag on both the `chrono` and the `bytes` crates. Since we re-export those from `prosa-utils`, we should add a `serde` feature flag that enable them both at once.